### PR TITLE
Run MacOS pre-release verification by default

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -236,8 +236,6 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
 #{{- if not .Config.NoSchema }}#
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false
@@ -60,11 +55,7 @@ jobs:
     strategy:
       matrix:
 #{{- if .Config.ReleaseVerification }}#
-        # We always run on Linux and Windows, and optionally on MacOS. This is because MacOS runners have limited availability.
-        # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
-        # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
-        # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }}
+        runner: ["ubuntu-latest", "windows-latest", "macos-latest"]
 #{{- else }}#
         # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
         runner: ["ubuntu-latest"]

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -190,7 +190,5 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -226,7 +226,5 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false
@@ -67,11 +62,7 @@ jobs:
     name: verify-release
     strategy:
       matrix:
-        # We always run on Linux and Windows, and optionally on MacOS. This is because MacOS runners have limited availability.
-        # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
-        # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
-        # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }}
+        runner: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: 'read'

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -223,7 +223,5 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -236,7 +236,5 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -228,7 +228,5 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false

--- a/provider-ci/test-providers/terraform-module/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/publish.yml
@@ -130,6 +130,4 @@ jobs:
     secrets: inherit
     with:
       providerVersion: ${{ inputs.version }}
-      # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/verify-release.yml
@@ -26,11 +26,6 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacRunner:
-        description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
-        required: false
-        type: boolean
-        default: false
       skipGoSdk:
         description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
         required: false


### PR DESCRIPTION
This PR enables MacOS verification by default for pre-releases as well. Previously, these verifications were skipped due to concerns about MacOS runner exhaustion and the strain on available machine types. Since resource quotas are no longer a concern, this verification can now be enabled by default.

Closes: #1313