### PR TITLE
Optimize run-acceptance-tests: only build linux binaries

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       #{{- if .Config.FreeDiskSpaceBeforeBuild }}#
       # Run as first step so we don't delete things that have just been installed

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -39,6 +39,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   #{{ if not .Config.NoSchema -}}#
   build_sdk:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -54,6 +54,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       # Run as first step so we don't delete things that have just been installed
       - name: Free Disk Space (Ubuntu)

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -57,6 +57,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -56,6 +56,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -69,6 +69,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -61,6 +61,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -9,6 +9,19 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      matrix:
+        required: false
+        type: string
+        default: |
+          {
+            "platform": [
+              {"os": "linux",   "arch": "amd64"},
+              {"os": "linux",   "arch": "arm64"},
+              {"os": "darwin",  "arch": "amd64"},
+              {"os": "darwin",  "arch": "arm64"},
+              {"os": "windows", "arch": "amd64"}
+            ]
+          }
 
 jobs:
   build_provider:
@@ -19,18 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: true
-      matrix:
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: windows
-            arch: amd64
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
@@ -55,6 +55,12 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      matrix: |
+        {
+          "platform": [
+            {"os": "linux", "arch": "amd64"},
+          ]
+        }
 
   
 


### PR DESCRIPTION
A small optimization: when verifying PRs we only use the linux binary for amd64; with this change the runner will stop trying to build the binary for every other architecture and platform in this job.