### PR TITLE
Bump golangci-lint version

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
@@ -38,5 +38,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: #{{ .Config.ModulePath }}#

--- a/provider-ci/test-providers/acme/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/lint.yml
@@ -50,5 +50,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: provider

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -54,5 +54,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -52,5 +52,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: provider

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -65,5 +65,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: provider

--- a/provider-ci/test-providers/eks/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/lint.yml
@@ -57,5 +57,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: provider

--- a/provider-ci/test-providers/terraform-module/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/lint.yml
@@ -51,5 +51,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
       with:
-        version: v1.60
+        version: v1.64.6
         working-directory: .


### PR DESCRIPTION
The current version fails when used with go 1.24

Native providers seem to manage this in-repo in the ci-mgmt.yml config.

fixes https://github.com/pulumi/ci-mgmt/issues/1432