### PR TITLE
publish_sdk no longer consults the Go cache

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -137,6 +137,7 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
+        cache-go: false
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -121,6 +121,7 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, dotnet, go, nodejs, python
+        cache-go: false
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -138,6 +138,7 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        cache-go: false
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -135,6 +135,7 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        cache-go: false
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -148,6 +148,7 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        cache-go: false
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -140,6 +140,7 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        cache-go: false
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21


### PR DESCRIPTION
Motivated by:

https://github.com/pulumi/pulumi-aws/issues/5337
https://github.com/pulumi/pulumi-aws/issues/5122

I was only able to resolve 5337 that kept failing on the publish_sdk step by clearing caches and a targeted re-run.  The AWS caches are too large. In particular the default Go cache. I think publish_sdk is better off opting out of Go cache just like `publish` is opting out of Go cache as they are not doing any particularly heavy Go compilation, and doing this alleviates the problem of downloading large caches and running out of disk space.