### PR TITLE
Switch AWS credentials to esc for base workflow

### DIFF
--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -50,6 +50,12 @@ jobs:
       - name: google-github-actions/auth
         uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
 
+      - name: pulumi/auth-actions
+        uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
+
+      - name: pulumi/esc-action
+        uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+
       # Tools
 
       - name: goreleaser/goreleaser-action

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -365,6 +365,8 @@ type actions struct {
 
 type actionVersions struct {
 	ConfigureAwsCredentials string `yaml:"configureAwsCredentials"`
+	ESCAuth                 string `yaml:"escAuth"`
+	ESCAction               string `yaml:"escAction"`
 	SetupGcloud             string `yaml:"setupGcloud"`
 	GoogleAuth              string `yaml:"googleAuth"`
 	Checkout                string `yaml:"checkout"`
@@ -433,6 +435,10 @@ func loadDefaultConfig() (Config, error) {
 						switch name {
 						case "aws-actions/configure-aws-credentials":
 							config.ActionVersions.ConfigureAwsCredentials = uses
+						case "pulumi/auth-actions":
+							config.ActionVersions.ESCAuth = uses
+						case "pulumi/esc-action":
+							config.ActionVersions.ESCAction = uses
 						case "google-github-actions/setup-gcloud":
 							config.ActionVersions.SetupGcloud = uses
 						case "google-github-actions/auth":

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -95,15 +95,19 @@ jobs:
       run: docker compose -f testing/docker-compose.yml up --build -d
     #{{- end }}#
     #{{- if .Config.AWS }}#
-    - name: Configure AWS Credentials
-      uses: #{{ .Config.ActionVersions.ConfigureAwsCredentials }}#
+    - name: Generate Pulumi Access Token
+      id: generate_pulumi_token
+      uses: #{{ .Config.ActionVersions.ESCAuth }}#
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 7200
-        role-session-name: #{{ .Config.Provider }}#@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        organization: pulumi
+        requested-token-type: urn:pulumi:token-type:access_token:organization
+        export-environment-variables: false
+    - name: Export AWS Credentials
+      uses: #{{ .Config.ActionVersions.ESCAction }}#
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+      with:
+        environment: logins/pulumi-ci
     #{{- end }}#
     #{{- if .Config.GCP }}#
     - name: Authenticate to Google Cloud

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -79,15 +79,19 @@ jobs:
           tools: pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
 #{{- if .Config.ReleaseVerification }}#
       #{{- if .Config.AWS }}#
-      - name: Configure AWS Credentials
-        uses: #{{ .Config.ActionVersions.ConfigureAwsCredentials }}#
+      - name: Generate Pulumi Access Token
+        id: generate_pulumi_token
+        uses: #{{ .Config.ActionVersions.ESCAuth }}#
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 7200
-          role-session-name: #{{ .Config.Provider }}#@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          export-environment-variables: false
+      - name: Export AWS Credentials
+        uses: #{{ .Config.ActionVersions.ESCAction }}#
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+        with:
+          environment: logins/pulumi-ci
       #{{- end }}#
       #{{- if .Config.GCP }}#
       - name: Authenticate to Google Cloud

--- a/provider-ci/test-providers/docker/.github/workflows/test.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/test.yml
@@ -85,15 +85,19 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+    - name: Generate Pulumi Access Token
+      id: generate_pulumi_token
+      uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 7200
-        role-session-name: docker@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        organization: pulumi
+        requested-token-type: urn:pulumi:token-type:access_token:organization
+        export-environment-variables: false
+    - name: Export AWS Credentials
+      uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+      with:
+        environment: logins/pulumi-ci
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
       with:

--- a/provider-ci/test-providers/eks/.github/workflows/test.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/test.yml
@@ -96,15 +96,19 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+    - name: Generate Pulumi Access Token
+      id: generate_pulumi_token
+      uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 7200
-        role-session-name: eks@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        organization: pulumi
+        requested-token-type: urn:pulumi:token-type:access_token:organization
+        export-environment-variables: false
+    - name: Export AWS Credentials
+      uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+      with:
+        environment: logins/pulumi-ci
     - name: Install prebuilt SDKs
       run: make install_sdks
     - name: Generate test shards

--- a/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
@@ -57,15 +57,19 @@ jobs:
       uses: ./.github/actions/download-provider
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+    - name: Generate Pulumi Access Token
+      id: generate_pulumi_token
+      uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 7200
-        role-session-name: terraform-module@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        organization: pulumi
+        requested-token-type: urn:pulumi:token-type:access_token:organization
+        export-environment-variables: false
+    - name: Export AWS Credentials
+      uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+      with:
+        environment: logins/pulumi-ci
     - name: Generate test shards
       run: |-
         cd tests


### PR DESCRIPTION
This switches the AWS Access from hardcoded access keys that are pulled from GitHub secrets to use Pulumi ESC environments.

Tested in awsx in this pr https://github.com/pulumi/pulumi-awsx/pull/1563

re [#3731](https://github.com/pulumi/home/issues/3731)