### PR TITLE
Fix verify-release on windows

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -86,6 +86,14 @@ jobs:
           organization: pulumi
           requested-token-type: urn:pulumi:token-type:access_token:organization
           export-environment-variables: false
+      # workaround for https://github.com/pulumi/esc-action/issues/10
+      - name: Install esc on Windows
+        if: ${{ matrix.runner == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/esc/install.ps1'))
+          Copy-Item "$env:USERPROFILE\.pulumi\bin\esc.exe" "C:\Windows\System32\esc.exe"
       - name: Export AWS Credentials
         uses: #{{ .Config.ActionVersions.ESCAction }}#
         env:


### PR DESCRIPTION
The `esc-action` will try to automatically install `esc` if it is not
already installed, but it currently does not support installing on
windows runners (see https://github.com/pulumi/esc-action/issues/10).

This adds a step when running on windows to install esc manually.

I tested this configuration here https://github.com/pulumi/pulumi-aws-apigateway/actions/runs/14068439461/job/39396604197