### PR TITLE
Remove unused paths (mostly azure-native related) from native-provider-ci

### DIFF
--- a/native-provider-ci/src/goreleaser.ts
+++ b/native-provider-ci/src/goreleaser.ts
@@ -147,11 +147,7 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
           ],
         };
       }
-      if (
-        opts.provider === "aws-native" ||
-        opts.provider === "azure-native" ||
-        opts.provider === "google-native"
-      ) {
+      if (opts.provider === "aws-native" || opts.provider === "google-native") {
         this.before = {
           hooks: [
             "make init_submodules",
@@ -186,8 +182,8 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
         hooks: { post: ["make sign-goreleaser-exe-{{ .Arch }}"] },
       },
     ];
-    // Don't disable CGO for azure-native and aws-native to support mac users
-    if (opts.provider === "azure-native" || opts.provider === "aws-native") {
+    // Don't disable CGO for aws-native to support mac users
+    if (opts.provider === "aws-native") {
       this.builds = [
         {
           dir: "provider",

--- a/native-provider-ci/src/provider.ts
+++ b/native-provider-ci/src/provider.ts
@@ -90,22 +90,6 @@ export const buildProviderFiles = (provider: string): ProviderFile[] => {
       }
     );
   }
-  if (config.provider === "azure-native") {
-    files.push(
-      {
-        path: path.join(githubWorkflowsDir, "arm2pulumi-release.yml"),
-        data: wf.Arm2PulumiReleaseWorkflow("arm2pulumi-release", config),
-      },
-      {
-        path: path.join(githubWorkflowsDir, "arm2pulumi-coverage-report.yml"),
-        data: wf.Arm2PulumiCoverageReportWorkflow("generate-coverage", config),
-      },
-      {
-        path: path.join(githubWorkflowsDir, "nightly-sdk-generation.yml"),
-        data: wf.NightlySdkGenerationWorkflow("nightly-sdk-generation", config),
-      }
-    );
-  }
   if (config.provider === "google-native") {
     files.push({
       path: path.join(githubWorkflowsDir, "nightly-sdk-generation.yml"),

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -61,9 +61,6 @@ export function CreateCommentsUrlStep(): Step {
 
 export function SetGitSubmoduleCommitHash(provider: string): Step {
   let dir;
-  if (provider === "azure-native") {
-    dir = "azure-rest-api-specs";
-  }
   if (provider === "aws-native") {
     dir = "aws-cloudformation-user-guide";
   }
@@ -80,9 +77,6 @@ export function SetGitSubmoduleCommitHash(provider: string): Step {
 
 export function CommitAutomatedSDKUpdates(provider: string): Step {
   let dir;
-  if (provider === "azure-native") {
-    dir = "azure-rest-api-specs";
-  }
   if (provider === "aws-native") {
     dir = "aws-cloudformation-user-guide";
   }
@@ -458,18 +452,7 @@ export function UploadSDKs(tag: boolean): Step {
   };
 }
 
-export function DownloadProviderBinaries(provider: string, job: string): Step {
-  if (provider === "azure-native" && job === "build_sdks") {
-    return {
-      name: "Download provider + tfgen binaries",
-      if: "${{ matrix.language != 'dotnet' }}",
-      uses: action.downloadArtifact,
-      with: {
-        name: "pulumi-${{ env.PROVIDER }}-provider.tar.gz",
-        path: "${{ github.workspace }}/bin",
-      },
-    };
-  }
+export function DownloadProviderBinaries(): Step {
   return {
     name: "Download provider + tfgen binaries",
     uses: action.downloadArtifact,
@@ -602,9 +585,6 @@ export function PullRequestSdkGeneration(
   branch: string
 ): Step {
   let dir;
-  if (provider === "azure-native") {
-    dir = "azure-rest-api-specs";
-  }
   if (provider === "aws-native") {
     dir = "aws-cloudformation-user-guide";
   }
@@ -757,14 +737,7 @@ export function TestProviderLibrary(): Step {
   };
 }
 
-export function RestoreBinaryPerms(provider: string, job: string): Step {
-  if (provider === "azure-native" && job === "build_sdks") {
-    return {
-      name: "Restore Binary Permissions",
-      if: "${{ matrix.language != 'dotnet' }}",
-      run: 'find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \\;',
-    };
-  }
+export function RestoreBinaryPerms(): Step {
   return {
     name: "Restore Binary Permissions",
     run: 'find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \\;',
@@ -917,14 +890,7 @@ export function TarProviderBinaries(hasGenBinary: boolean): Step {
   };
 }
 
-export function UnTarProviderBinaries(provider: string, job: string): Step {
-  if (provider === "azure-native" && job === "build_sdks") {
-    return {
-      name: "UnTar provider binaries",
-      if: "${{ matrix.language != 'dotnet' }}",
-      run: "tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin",
-    };
-  }
+export function UnTarProviderBinaries(): Step {
   return {
     name: "UnTar provider binaries",
     run: "tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin",
@@ -987,17 +953,6 @@ export function GolangciLint(): Step[] {
   };
 
   return [disarmGoEmbed, lintStep];
-}
-
-export function CodegenDuringSDKBuild(provider: string) {
-  if (provider === "azure-native") {
-    return {
-      name: "Build Codegen",
-      if: "${{ matrix.language == 'dotnet' }}",
-      run: "make codegen",
-    };
-  }
-  return {};
 }
 
 export function UpdatePulumi(): Step {
@@ -1199,33 +1154,6 @@ export function ChocolateyPackageDeployment(): Step {
   };
 }
 
-export function AzureLogin(provider: string): Step {
-  if (provider === "azure-native") {
-    return {
-      uses: action.azureLogin,
-      with: {
-        creds: "${{ secrets.AZURE_RBAC_SERVICE_PRINCIPAL }}",
-      },
-    };
-  }
-  return {};
-}
-
-export function AwsCredentialsForArmCoverageReport(): Step {
-  return {
-    name: "Configure AWS Credentials",
-    uses: action.configureAwsCredentials,
-    with: {
-      "aws-access-key-id": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-      "aws-region": "us-west-2",
-      "aws-secret-access-key": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-      "role-duration-seconds": 3600,
-      "role-session-name": "arm2pulumiCvg@githubActions",
-      "role-to-assume": "${{ secrets.AWS_CI_ROLE_ARN }}",
-    },
-  };
-}
-
 export function MakeClean(): Step {
   return {
     name: "Cleanup SDK Folder",
@@ -1254,13 +1182,6 @@ export function TestResultsJSON(): Step {
   };
 }
 
-export function UploadArmCoverageToS3(): Step {
-  return {
-    name: "Upload results to S3",
-    run: "cd provider/pkg/arm2pulumi/internal/test && bash s3-upload-script.sh",
-  };
-}
-
 export function PrepareGitBranchForSdkGeneration(): Step {
   return {
     name: "Preparing Git Branch",
@@ -1268,16 +1189,6 @@ export function PrepareGitBranchForSdkGeneration(): Step {
       'git config --local user.email "bot@pulumi.com"\n' +
       'git config --local user.name "pulumi-bot"\n' +
       "git checkout -b generate-sdk/${{ github.run_id }}-${{ github.run_number }}\n",
-  };
-}
-
-export function UpdateSubmodules(provider: string): Step {
-  if (provider !== "azure-native") {
-    return {};
-  }
-  return {
-    name: "Update Submodules",
-    run: "make update_submodules",
   };
 }
 

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { GithubWorkflow, NormalJob, PermissionsEvent } from "./github-workflow";
+import { GithubWorkflow, NormalJob } from "./github-workflow";
 import * as steps from "./steps";
 import { Step } from "./steps";
 
@@ -153,9 +153,11 @@ export function RunAcceptanceTestsWorkflow(
         "prerequisites",
         opts
       ).addDispatchConditional(true),
-      build_sdks: new BuildSdkJob("build_sdks", opts, false)
-        .addDispatchConditional(true)
-        .addRunsOn(opts.provider),
+      build_sdks: new BuildSdkJob(
+        "build_sdks",
+        opts,
+        false
+      ).addDispatchConditional(true),
       test: new TestsJob(name, "test", opts).addDispatchConditional(true),
       sentinel: new EmptyJob("sentinel")
         .addPermissions({ statuses: "write" })
@@ -210,9 +212,7 @@ export function BuildWorkflow(
     env: azureEnv(env(opts)),
     jobs: {
       prerequisites: new PrerequisitesJob("prerequisites", opts),
-      build_sdks: new BuildSdkJob("build_sdks", opts, false).addRunsOn(
-        opts.provider
-      ),
+      build_sdks: new BuildSdkJob("build_sdks", opts, false),
       test: new TestsJob(name, "test", opts),
       publish: new PublishPrereleaseJob("publish", opts),
       publish_sdk: new PublishSDKJob("publish_sdk"),
@@ -382,57 +382,6 @@ export function Cf2PulumiReleaseWorkflow(
   };
 }
 
-// creates arm2pulumi-coverage-report.yml
-export function Arm2PulumiCoverageReportWorkflow(
-  name: string,
-  opts: WorkflowOpts
-): GithubWorkflow {
-  return {
-    name: name,
-    on: {
-      schedule: [
-        {
-          cron: "35 17 * * *",
-        },
-      ],
-      workflow_dispatch: {},
-    },
-    env: env(opts),
-    jobs: {
-      "generate-coverage": new Arm2PulumiCoverageReport("coverage-report"),
-    },
-  };
-}
-
-// creates arm2pulumi-release.yml
-export function Arm2PulumiReleaseWorkflow(
-  name: string,
-  opts: WorkflowOpts
-): GithubWorkflow {
-  return {
-    name: name,
-    on: {
-      push: {
-        tags: ["v*.*.*", "!v*.*.*-**"],
-      },
-      workflow_dispatch: {
-        inputs: {
-          version: {
-            description:
-              "The version of the binary to deploy - do not include the pulumi prefix in the name.",
-            required: true,
-            type: "string",
-          },
-        },
-      },
-    },
-    env: env(opts),
-    jobs: {
-      release: new Arm2PulumiRelease("release"),
-    },
-  };
-}
-
 // This section represents sub-jobs that may be used in more than one workflow
 
 export class BuildSdkJob implements NormalJob {
@@ -451,10 +400,7 @@ export class BuildSdkJob implements NormalJob {
   if: NormalJob["if"];
 
   constructor(name: string, opts: WorkflowOpts, tag: boolean) {
-    if (opts.provider === "azure-native") {
-      this["runs-on"] =
-        "${{ matrix.language == 'dotnet' && 'macos-latest' || 'ubuntu-latest' }}";
-    } else if (opts.provider === "command") {
+    if (opts.provider === "command") {
       this["runs-on"] = "ubuntu-latest";
     }
     this.name = name;
@@ -469,10 +415,9 @@ export class BuildSdkJob implements NormalJob {
       steps.InstallPython(),
       steps.InstallJava(),
       steps.InstallGradle("7.6"),
-      steps.DownloadProviderBinaries(opts.provider, name),
-      steps.UnTarProviderBinaries(opts.provider, name),
-      steps.RestoreBinaryPerms(opts.provider, name),
-      steps.CodegenDuringSDKBuild(opts.provider),
+      steps.DownloadProviderBinaries(),
+      steps.UnTarProviderBinaries(),
+      steps.RestoreBinaryPerms(),
       steps.InitializeSubModules(opts.submodules),
       steps.GenerateSDKs(opts.provider, opts.hasGenBinary),
       steps.BuildSDKs(opts.provider, opts.hasGenBinary),
@@ -493,14 +438,6 @@ export class BuildSdkJob implements NormalJob {
 
       this.steps = this.steps?.filter((step) => step.name !== "Checkout Repo");
       this.steps?.unshift(steps.CheckoutRepoStepAtPR());
-    }
-    return this;
-  }
-
-  addRunsOn(provider: string) {
-    if (provider === "azure-native") {
-      this["runs-on"] =
-        "${{ matrix.language == 'dotnet' && 'macos-latest' || 'ubuntu-latest' }}";
     }
     return this;
   }
@@ -618,9 +555,9 @@ export class TestsJob implements NormalJob {
       steps.InstallPython(),
       steps.InstallJava(),
       steps.InstallGradle("7.6"),
-      steps.DownloadProviderBinaries(opts.provider, jobName),
-      steps.UnTarProviderBinaries(opts.provider, jobName),
-      steps.RestoreBinaryPerms(opts.provider, jobName),
+      steps.DownloadProviderBinaries(),
+      steps.UnTarProviderBinaries(),
+      steps.RestoreBinaryPerms(),
       steps.DownloadSDKs(),
       steps.UnzipSDKs(),
       steps.UpdatePath(),
@@ -776,7 +713,7 @@ export class PublishPrereleaseJob implements NormalJob {
   steps: NormalJob["steps"];
   name: string;
   constructor(name: string, opts: WorkflowOpts) {
-    if (opts.provider === "azure-native" || opts.provider === "aws-native") {
+    if (opts.provider === "aws-native") {
       this["runs-on"] = "macos-latest";
     }
     this.name = name;
@@ -806,7 +743,7 @@ export class PublishJob implements NormalJob {
   constructor(name: string, opts: WorkflowOpts) {
     this.name = name;
     Object.assign(this, { name });
-    if (opts.provider === "azure-native" || opts.provider === "aws-native") {
+    if (opts.provider === "aws-native") {
       this["runs-on"] = "macos-latest";
     }
     this.steps = [
@@ -931,51 +868,6 @@ export class Cf2PulumiRelease implements NormalJob {
   }
 }
 
-export class Arm2PulumiRelease implements NormalJob {
-  "runs-on" = "macos-latest";
-  steps = [
-    steps.CheckoutRepoStep(),
-    steps.SetProviderVersionStep(),
-    steps.InstallPulumiCtl(),
-    steps.InstallGo(goVersion),
-    steps.RunGoReleaserWithArgs(
-      "-p 1 -f .goreleaser.arm2pulumi.yml release --clean --timeout 60m0s"
-    ),
-  ];
-  name: string;
-
-  constructor(name: string) {
-    this.name = name;
-    Object.assign(this, { name });
-  }
-}
-
-export class Arm2PulumiCoverageReport implements NormalJob {
-  "runs-on" = "ubuntu-latest";
-  steps = [
-    steps.CheckoutRepoStep(),
-    steps.InstallGo(goVersion),
-    steps.InstallPulumiCtl(),
-    steps.InstallPulumiCli(),
-    steps.AzureLogin("azure-native"),
-    steps.MakeClean(),
-    steps.InitializeSubModules(true),
-    steps.BuildCodegenBinaries("azure-native"),
-    steps.MakeLocalGenerate(),
-    steps.BuildProvider("azure-native"),
-    steps.GenerateCoverageReport(),
-    steps.TestResultsJSON(),
-    steps.AwsCredentialsForArmCoverageReport(),
-    steps.UploadArmCoverageToS3(),
-  ];
-  name: string;
-
-  constructor(name: string) {
-    this.name = name;
-    Object.assign(this, { name });
-  }
-}
-
 export class WeeklyPulumiUpdate implements NormalJob {
   "runs-on" = "ubuntu-latest";
   steps: NormalJob["steps"];
@@ -1023,11 +915,9 @@ export class NightlySdkGeneration implements NormalJob {
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion, opts.pulumiVersionFile),
       ...awsCredentialSteps,
-      steps.AzureLogin(opts.provider),
       steps.MakeClean(),
       steps.PrepareGitBranchForSdkGeneration(),
       steps.CommitEmptySDK(),
-      steps.UpdateSubmodules(opts.provider),
       steps.MakeDiscovery(opts.provider),
       steps.BuildCodegenBinaries(opts.provider),
       steps.MakeLocalGenerate(),


### PR DESCRIPTION
Our goal is for all providers to user provider-ci, and we don't ever plan to hook azure-native back up to the native-provider-ci. This leaves a lot of abandoned code in native-provider-ci that we can remove to hopefully leave that project a little easier to read/update as needed. 