### PR TITLE
Remove Onelogin provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
+++ b/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
@@ -86,7 +86,6 @@ assignees: ''
 - [ ] [null](https://github.com/pulumi/pulumi-null)
 - [ ] [oci](https://github.com/pulumi/pulumi-oci)
 - [ ] [okta](https://github.com/pulumi/pulumi-okta)
-- [ ] [onelogin](https://github.com/pulumi/pulumi-onelogin)
 - [ ] [openstack](https://github.com/pulumi/pulumi-openstack)
 - [ ] [opsgenie](https://github.com/pulumi/pulumi-opsgenie)
 - [ ] [pagerduty](https://github.com/pulumi/pulumi-pagerduty)

--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -51,7 +51,6 @@
     "null",
     "oci",
     "okta",
-    "onelogin",
     "openstack",
     "opsgenie",
     "pagerduty",


### PR DESCRIPTION
We no longer support this provider: https://github.com/pulumi/pulumi-onelogin. It should be removed from automations.
