### PR TITLE
Drop wildcard to prevent accidental collisions

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -164,7 +164,7 @@ build_nodejs: .make/build_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/
 	@touch $@
 .PHONY: generate_nodejs build_nodejs
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -148,7 +148,7 @@ build_nodejs: .make/build_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/
 	@touch $@
 .PHONY: generate_nodejs build_nodejs
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -148,7 +148,7 @@ build_nodejs: .make/build_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/
 	@touch $@
 .PHONY: generate_nodejs build_nodejs
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -148,7 +148,7 @@ build_nodejs: .make/build_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/
 	@touch $@
 .PHONY: generate_nodejs build_nodejs
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -148,7 +148,7 @@ build_nodejs: .make/build_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/
 	@touch $@
 .PHONY: generate_nodejs build_nodejs
 

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -148,7 +148,7 @@ build_nodejs: .make/build_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/
 	@touch $@
 .PHONY: generate_nodejs build_nodejs
 


### PR DESCRIPTION
I’m helping @scraly from OVH to adopt ci-mgmt. In their repositories, they have a top-level folder called LICENSES which is populated by a central process.

When rolling out the external-provider-template for the ovh/pulumi-ovh repository, the copy command in .make/build_nodejs includes ../../LICENSE* (with wildcard). This wildcard matches folder LICENSES but the copy command fails because it only expects files.

I checked the filenames of the LICENSE files in pulumi and pulumiverse organization and all seem to be an exact match with LICENSE without file extension.

https://github.com/search?q=org%3Apulumi%20LICENSE.txt&type=code

https://github.com/search?q=org%3Apulumi%20LICENSE.md&type=code

https://github.com/search?q=org%3Apulumiverse+LICENSE.txt&type=code&p=1

https://github.com/search?q=org%3Apulumiverse+LICENSE.md&type=code&p=1

So I think this is a safe change.