### PR TITLE
Don't mention tfgen binaries in native providers names

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -305,7 +305,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
@@ -466,7 +466,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -294,7 +294,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
@@ -453,7 +453,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
@@ -455,7 +455,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -314,7 +314,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
@@ -474,7 +474,7 @@ jobs:
       uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: "7.6"
-    - name: Download provider + tfgen binaries
+    - name: Download provider
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz


### PR DESCRIPTION
Native providers don't always have a generation binary, and the if they do, it is never from `tfgen` (Terraform generation). This PR changes the name of the download job from `Download provider + tfgen binaries` to `Download provider`.

The first commit is the manual change. The second commit is the result of running `make build` to regenerate checked in CI scripts.