### PR TITLE
Add exceptions to support pulumi-terraform

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Make Kubernetes provider
       run: make k8sprovider
     #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
+    #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
@@ -125,8 +125,6 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -135,8 +133,6 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment-tag: schemaCheck
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -205,7 +201,7 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        #{{- if ne .Config.Provider "command" }}#
+        #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
         pulumi-gen-${{ env.PROVIDER}}
         #{{- end }}#
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Make Kubernetes provider
       run: make k8sprovider
     #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
+    #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
@@ -114,8 +114,6 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -124,8 +122,6 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment-tag: schemaCheck
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -194,7 +190,7 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        #{{- if ne .Config.Provider "command" }}#
+        #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
         pulumi-gen-${{ env.PROVIDER}}
         #{{- end }}#
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Make Kubernetes provider
       run: make k8sprovider
     #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
+    #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
@@ -114,8 +114,6 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -124,8 +122,6 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment-tag: schemaCheck
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -194,7 +190,7 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        #{{- if ne .Config.Provider "command" }}#
+        #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
         pulumi-gen-${{ env.PROVIDER}}
         #{{- end }}#
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Make Kubernetes provider
       run: make k8sprovider
     #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
+    #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
@@ -130,8 +130,6 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -140,8 +138,6 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment-tag: schemaCheck
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    #{{- end }}#
-    #{{- if ne .Config.Provider "command" }}#
     - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -210,7 +206,7 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        #{{- if ne .Config.Provider "command" }}#
+        #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
         pulumi-gen-${{ env.PROVIDER}}
         #{{- end }}#
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/native/.goreleaser.prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.goreleaser.prerelease.yml
@@ -55,7 +55,9 @@ builds:
   - amd64
   - arm64
   ignore: &a1 []
+#{{- if ne .Config.Provider "terraform" }}#
   main: ./cmd/pulumi-resource-#{{ .Config.Provider }}#/
+#{{- end }}#
   ldflags: &a2
     - -s
     - -w
@@ -83,7 +85,9 @@ builds:
   - amd64
   - arm64
   ignore: *a1
+#{{- if ne .Config.Provider "terraform" }}#
   main: ./cmd/pulumi-resource-#{{ .Config.Provider }}#/
+#{{- end }}#
   ldflags: *a2
   binary: pulumi-resource-#{{ .Config.Provider }}#
   hooks:

--- a/provider-ci/internal/pkg/templates/native/.goreleaser.yml
+++ b/provider-ci/internal/pkg/templates/native/.goreleaser.yml
@@ -55,7 +55,9 @@ builds:
   - amd64
   - arm64
   ignore: &a1 []
+#{{- if ne .Config.Provider "terraform" }}#
   main: ./cmd/pulumi-resource-#{{ .Config.Provider }}#/
+#{{- end }}#
   ldflags: &a2
     - -s
     - -w
@@ -83,7 +85,9 @@ builds:
   - amd64
   - arm64
   ignore: *a1
+#{{- if ne .Config.Provider "terraform" }}#
   main: ./cmd/pulumi-resource-#{{ .Config.Provider }}#/
+#{{- end }}#
   ldflags: *a2
   binary: pulumi-resource-#{{ .Config.Provider }}#
   hooks:


### PR DESCRIPTION
This enables ci-mgmt to generate the CI for https://github.com/pulumi/pulumi-terraform (post https://github.com/pulumi/pulumi-terraform/pull/769).

The PR does not effect any other providers. To match the CI scripts found in https://github.com/pulumi/pulumi-terraform/pull/769, this PR needs to be stacked on top of #1491 and #1492.

dabadc905acabe096d2a62bd8cc50ab5b35ddd0b is a stack of all the PRs needed to get pulumi-terraform to fully comply with ci-mgmt. Running `make ci-mgmt` in pulumi-terraform on that version yields only the changes shown in <https://github.com/pulumi/pulumi-command/pull/737/files>.