### PR TITLE
Applying upstream patches should ignore whitespace differences

### DIFF
--- a/provider-ci/internal/pkg/templates/base/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/base/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done

--- a/provider-ci/test-providers/acme/scripts/upstream.sh
+++ b/provider-ci/test-providers/acme/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done

--- a/provider-ci/test-providers/aws/scripts/upstream.sh
+++ b/provider-ci/test-providers/aws/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done

--- a/provider-ci/test-providers/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done

--- a/provider-ci/test-providers/docker/scripts/upstream.sh
+++ b/provider-ci/test-providers/docker/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done

--- a/provider-ci/test-providers/eks/scripts/upstream.sh
+++ b/provider-ci/test-providers/eks/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done

--- a/provider-ci/test-providers/terraform-module/scripts/upstream.sh
+++ b/provider-ci/test-providers/terraform-module/scripts/upstream.sh
@@ -237,7 +237,7 @@ checkout() {
   # Allow directory to be empty
   shopt -s nullglob
   for patch in ../patches/*.patch; do
-    if ! git am --3way "${patch}"; then
+    if ! git am --ignore-whitespace --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done


### PR DESCRIPTION
I ran into this in
[pulumi-gcp](https://github.com/pulumi/pulumi-gcp/pull/3176) where one
of the patches will apply with `git apply` because `apply` ignores
whitespace differences, but the patch fails to apply with `git am` because
`am` doesn't ignore whitspace differences.

This should be safe to take because if the patches are created/applied
on one machine, but upstream was created on another, whitespace changes
may be unavoidable and do not cause a material difference.