### PR TITLE
Add patch release option

### DIFF
--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -118,8 +118,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
 
       - name: pulumi/pulumi-upgrade-provider-action
-        uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
-        # TODO Bump version after release
+        uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
 
       - name: jlumbroso/free-disk-space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -119,6 +119,7 @@ jobs:
 
       - name: pulumi/pulumi-upgrade-provider-action
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+        # TODO Bump version after release
 
       - name: jlumbroso/free-disk-space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      patch-release:
+        description: Whether to create a patch release
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -100,6 +105,7 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: ${{ inputs.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: #{{ .Config.ActionVersions.UpgradeProviderAction }}#
@@ -113,3 +119,4 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      patch-release:
+        description: Whether to create a patch release
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -100,6 +105,7 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: ${{ inputs.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
@@ -113,3 +119,4 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
@@ -94,7 +94,7 @@ jobs:
         tools: pulumictl, pulumicli, dotnet, go, nodejs, python
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -108,7 +108,7 @@ jobs:
         patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -71,7 +71,7 @@ jobs:
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
         continue-on-error: true
-        uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+        uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
         with:
           kind: provider
           email: bot@pulumi.com

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      patch-release:
+        description: Whether to create a patch release
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -111,6 +116,7 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: ${{ inputs.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
@@ -124,3 +130,4 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -105,7 +105,7 @@ jobs:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -119,7 +119,7 @@ jobs:
         patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -79,7 +79,7 @@ jobs:
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
         continue-on-error: true
-        uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+        uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
         with:
           kind: provider
           email: bot@pulumi.com

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      patch-release:
+        description: Whether to create a patch release
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -102,6 +107,7 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: ${{ inputs.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
@@ -115,3 +121,4 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -96,7 +96,7 @@ jobs:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -110,7 +110,7 @@ jobs:
         patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      patch-release:
+        description: Whether to create a patch release
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -115,6 +120,7 @@ jobs:
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: ${{ inputs.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
@@ -128,3 +134,4 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
+        patch-release: ${{ github.event.client_payload.patch-release }}

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -109,7 +109,7 @@ jobs:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -123,7 +123,7 @@ jobs:
         patch-release: ${{ github.event.client_payload.patch-release }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+      uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -71,7 +71,7 @@ jobs:
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
         continue-on-error: true
-        uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
+        uses: pulumi/pulumi-upgrade-provider-action@819d5a53c48d0c7ddd67acbc82eb220b342084eb # v0.0.16
         with:
           kind: provider
           email: bot@pulumi.com


### PR DESCRIPTION
This PR propagates the patch-release option to all upgrade-bridge workflows in providers. I still need to bump the upgrade-provider-action version after that PR is merged and released.

Related to https://github.com/pulumi/pulumi-upgrade-provider-action/pull/38

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2267