### PR TITLE
Also build ARM binaries for windows

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -19,7 +19,8 @@ on:
               {"os": "linux",   "arch": "arm64"},
               {"os": "darwin",  "arch": "amd64"},
               {"os": "darwin",  "arch": "arm64"},
-              {"os": "windows", "arch": "amd64"}
+              {"os": "windows", "arch": "amd64"},
+              {"os": "windows", "arch": "arm64"}
             ]
           }
 


### PR DESCRIPTION
We seem to have accidentally dropped ARM builds for windows when we switched away from goreleaser. This change should start building them again. 


Fixes https://github.com/pulumi/ci-mgmt/issues/1514