### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/close-pulumi-bot-prs.yml
+++ b/.github/workflows/close-pulumi-bot-prs.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # This calls close_outdated_bridge_prs.py as part of a daily cron.
 #
 name: Close pulumi-bot PRs
@@ -5,13 +6,19 @@ on:
   schedule:
   # 4 AM UTC ~ 9 PM PDT - specifically selected to avoid putting load on the CI system during working hours.
   - cron: 0 4 * * *
-  workflow_dispatch:
-
+  workflow_dispatch: null
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 jobs:
   close-outdated-prs:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: ./scripts/close_outdated_bridge_prs.py

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 on:
   pull_request:
     branches:
@@ -6,7 +7,11 @@ on:
   workflow_dispatch: {}
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,6 +20,9 @@ jobs:
     name: Run actionlint and shellcheck
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: lint workflows

--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -1,18 +1,26 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Merge Dependabot PRs
 
 on:
   workflow_dispatch: {}
   schedule:
     # 4:00AM every 4 days.
-    - cron:  '0 4 01/4 * *'
+    - cron: '0 4 01/4 * *'
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:
   generate-providers-list:
     name: "Generate Providers List"
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: get-providers
         run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"
@@ -25,6 +33,9 @@ jobs:
     needs: generate-providers-list
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Clone ci-mgmt
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: gh auth setup-git

--- a/.github/workflows/refresh-gh-branch-protection.yml
+++ b/.github/workflows/refresh-gh-branch-protection.yml
@@ -1,14 +1,23 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Refresh Provider GH Branch Protection Settings
 on:
   workflow_dispatch: {}
 env:
   GITHUB_OWNER: pulumi
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 jobs:
   deployment:
     if: github.event_name == 'workflow_dispatch'
     name: Pulumi Refresh
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -20,7 +29,7 @@ jobs:
           command: refresh
           stack-name: pulumi/production
           work-dir: infra/providers
-          github-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN_PRODUCTION }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_PRODUCTION }}

--- a/.github/workflows/test-provider-ci.yml
+++ b/.github/workflows/test-provider-ci.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Test Provider CI
 on:
   pull_request:
@@ -7,7 +8,11 @@ on:
   workflow_dispatch: {}
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +23,9 @@ jobs:
     name: Verify against testdata
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install golangci-lint
@@ -50,10 +58,13 @@ jobs:
     needs: deploy
     if: needs.deploy.outputs.pull_request_created == 'true'
     env:
-      GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,GITHUB_TOKEN=PULUMI_BOT_TOKEN
     strategy:
       fail-fast: false
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Await PR opened for pulumi-xyz
         run: |
           echo Await PR opened for pulumi-xyz
@@ -87,6 +98,9 @@ jobs:
     needs: downstream
     if: github.event_name == 'merge_group'
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Await PR merged
         run: while [[ $(gh pr view --repo "pulumi/pulumi-xyz" "${{ needs.downstream.outputs.pr_number }}" --json "state" --jq ".state") == "OPEN" ]]; do sleep 1; done
         timeout-minutes: 5

--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # This is the version of update-bridge=all-providers.yml scoped down to Ecosystem team owned providers.
 #
 # Generates a PR for the files in provider-ci/providers/* to each corresponding Pulumi provider.
@@ -15,11 +16,18 @@ on:
         default: false
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 jobs:
   generate-providers-list:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: get-providers
         run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"
@@ -39,13 +47,16 @@ jobs:
       matrix:
         provider: ${{ fromJson(needs.generate-providers-list.outputs.providers ) }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: pulumi-${{ matrix.provider }} main
         id: upgrade-on-main
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         continue-on-error: true
         with:
             workflow: upgrade-bridge.yml
-            token: ${{ secrets.PULUMI_BOT_TOKEN }} 
+            token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
             repo: pulumi/pulumi-${{ matrix.provider }}
             inputs: '{ "automerge": true }'
             ref: main
@@ -55,11 +66,9 @@ jobs:
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
             workflow: upgrade-bridge.yml
-            token: ${{ secrets.PULUMI_BOT_TOKEN }} 
+            token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
             repo: pulumi/pulumi-${{ matrix.provider }}
             ref: master
             inputs: '{ "automerge": true }'
-      # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1
-        

--- a/.github/workflows/update-bridge-single-ecosystem-provider.yml
+++ b/.github/workflows/update-bridge-single-ecosystem-provider.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # Performs a workflow_dispatch to run the upgrade-bridge workflow in a specified
 # provider.
 # Note that this workflow does not generate any files - workflows must already be generated and committed to this repo
@@ -17,18 +18,25 @@ on:
         type: string
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 jobs:
   update-bridge:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: pulumi-${{ github.event.inputs.provider }} main
         id: upgrade-on-main
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         continue-on-error: true
         with:
           workflow: upgrade-bridge.yml
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           repo: pulumi/pulumi-${{ github.event.inputs.provider }}
           ref: main
       - name: pulumi-${{ github.event.inputs.provider }} master
@@ -37,7 +45,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: upgrade-bridge.yml
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           repo: pulumi/pulumi-${{ github.event.inputs.provider }}
           ref: master
-

--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # This is the version of update-workflows-bridged-providers.yml scoped down to Ecosystem team owned providers.
 #
 # Generates a PR for the files in provider-ci/providers/* to each corresponding Pulumi provider.
@@ -17,11 +18,18 @@ on:
         type: boolean
         default: true
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 jobs:
   generate-providers-list:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: get-providers
         run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # Generates a PR for the files in provider-ci/providers/* to the corresponding
 # Pulumi provider. Note that this workflow does not generate any files -
 # workflows must already be generated and committed to this repo when this
@@ -16,7 +17,11 @@ name: Update GH workflows, single provider
         type: boolean
         default: false
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 jobs:
   deploy:
     uses: ./.github/workflows/update-workflows.yml

--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: update-workflows
 
 on:
@@ -29,18 +30,25 @@ on:
         description: "Whether a PR was created"
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:
   update_workflows:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Clone pulumi-${{ inputs.provider_name }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: pulumi/pulumi-${{ inputs.provider_name }}
           path: pulumi-${{ inputs.provider_name }}
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Get Go version to install
         id: go-version
         run: |
@@ -70,7 +78,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
           tag: v0.0.46
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           cache: enable
       - name: Clone ci-mgmt
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -93,7 +101,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         if: ${{ !inputs.skip_closing_prs }}
         with:
-          github-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           script: |
             const regex = /Update GitHub Actions workflows/i;
             const octokit = github.rest;
@@ -127,18 +135,16 @@ jobs:
           labels: "impact/no-changelog-required"
           title: "${{ inputs.downstream_test == true && '[DOWNSTREAM TEST] ' || ''}}Update GitHub Actions workflows."
           path: pulumi-${{ inputs.provider_name }}
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: "Set PR to auto-merge"
-        if:
-          steps.create-pr.outputs.pull-request-operation == 'created' && inputs.automerge
-          # Not all providers have auto-merge enabled, and we don't want to fail providers
-          # that don't have auto-merge enabled.
-          #
-          # After https://github.com/pulumi/home/issues/3140 is closed, we should remove
-          # `continue-on-error: true`.
+        if: steps.create-pr.outputs.pull-request-operation == 'created' && inputs.automerge
+        # Not all providers have auto-merge enabled, and we don't want to fail providers
+        # that don't have auto-merge enabled.
+        #
+        # After https://github.com/pulumi/home/issues/3140 is closed, we should remove
+        # `continue-on-error: true`.
         continue-on-error: true
         run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
-      # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1
     outputs:


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
