### PR TITLE
Fix golangci-lint bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,5 +29,11 @@
       matchPackageNames: ["goreleaser/goreleaser-action"],
       allowedVersions: "^5",
     },
+    {
+      // v7 only supports golangci-lint version 2.0 which requires config migration.
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["golangci/golangci-lint-action"],
+      allowedVersions: "^6",
+    },
   ],
 }


### PR DESCRIPTION
We're still using v1.x of golangci-lint, so we need to keep the action on v6.x for now.