### PR TITLE
Use pull request base as ref for schema-tools

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
-      default_branch: ${{ github.event.repository.default_branch }}
+      default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 


### PR DESCRIPTION
This pull request changes the `default_branch` input to schema-tools to use the base branch of the pull request that the PR is being made against.

This means schema-tools can compare changes on a feature branch, or a stack of PRs, and only show incremental changes, rather than only comparing against the repository default branch.
