### PR TITLE
Changes for boilerplate onboarding

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -185,7 +185,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -330,7 +330,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -363,7 +363,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -185,7 +186,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -331,6 +339,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -363,7 +372,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -142,6 +142,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -174,7 +175,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -318,6 +326,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -350,7 +359,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -141,7 +141,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -174,7 +174,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -317,7 +317,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -350,7 +350,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -174,7 +175,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -320,6 +328,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -352,7 +361,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -174,7 +174,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -319,7 +319,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -352,7 +352,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -190,7 +191,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -338,6 +346,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -370,7 +379,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -157,7 +157,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -190,7 +190,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -337,7 +337,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -370,7 +370,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -62,6 +62,7 @@
     "opsgenie",
     "pagerduty",
     "postgresql",
+    "provider-boilerplate",
     "rabbitmq",
     "rancher2",
     "random",

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +154,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -284,7 +284,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -317,7 +317,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +155,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -285,6 +293,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -317,7 +326,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -276,7 +276,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -309,7 +309,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -277,6 +285,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -309,7 +318,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -276,7 +276,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -309,7 +309,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -277,6 +285,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -309,7 +318,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -130,6 +130,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +163,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -297,6 +305,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -329,7 +338,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -129,7 +129,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +162,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -296,7 +296,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -329,7 +329,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -116,7 +117,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -229,6 +237,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -261,7 +270,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -116,7 +116,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -228,7 +228,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -261,7 +261,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -76,6 +76,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -108,7 +109,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -221,6 +229,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -253,7 +262,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -108,7 +108,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -220,7 +220,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -253,7 +253,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -108,7 +109,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -221,6 +229,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -253,7 +262,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -108,7 +108,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -220,7 +220,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -253,7 +253,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -91,7 +91,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -124,7 +124,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -240,7 +240,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -273,7 +273,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -92,6 +92,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -124,7 +125,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -241,6 +249,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -273,7 +282,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -161,7 +161,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -274,7 +274,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -307,7 +307,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -129,6 +129,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -161,7 +162,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -275,6 +283,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -307,7 +316,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -120,7 +120,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -153,7 +153,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -266,7 +266,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -299,7 +299,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -121,6 +121,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -153,7 +154,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -267,6 +275,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -299,7 +308,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -153,7 +153,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -266,7 +266,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -299,7 +299,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -153,7 +154,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -267,6 +275,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -299,7 +308,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -136,7 +136,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -169,7 +169,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -286,7 +286,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -319,7 +319,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -137,6 +137,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -169,7 +170,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -287,6 +295,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -319,7 +328,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +154,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -269,7 +269,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +302,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +155,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -270,6 +278,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +311,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -129,7 +129,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +162,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -281,7 +281,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +314,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -130,6 +130,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +163,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -282,6 +290,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +323,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +154,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -269,7 +269,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +302,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +155,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -270,6 +278,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +311,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -129,7 +129,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +162,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -281,7 +281,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +314,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -130,6 +130,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +163,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -282,6 +290,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +323,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +154,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -269,7 +269,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +302,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -154,7 +155,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -270,6 +278,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +311,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +147,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -146,7 +146,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -129,7 +129,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +162,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -281,7 +281,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +314,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -130,6 +130,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -162,7 +163,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -282,6 +290,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +323,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -156,7 +156,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -269,7 +269,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +302,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -156,7 +157,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -270,6 +278,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -302,7 +311,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -116,6 +116,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -148,7 +149,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -115,7 +115,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -148,7 +148,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -148,7 +149,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -262,6 +270,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +303,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -148,7 +148,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -261,7 +261,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -294,7 +294,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -132,6 +132,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -164,7 +165,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -282,6 +290,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/*.*.csproj
+          sdk/dotnet/version.txt
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +323,14 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset sdk/python/*/pulumi-plugin.json \
+            sdk/python/pyproject.toml \
+            sdk/dotnet/pulumi-plugin.json \
+            sdk/dotnet/*.*.csproj \
+            sdk/dotnet/version.txt \
+            sdk/go/*/pulumi-plugin.json \
+            sdk/go/*/internal/pulumiUtilities.go \
+            sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -131,7 +131,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -164,7 +164,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 
@@ -281,7 +281,7 @@ jobs:
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
-          sdk/dotnet/Pulumi.*.csproj
+          sdk/dotnet/*.*.csproj
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
@@ -314,7 +314,7 @@ jobs:
 
         git add sdk
 
-        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/python/pyproject.toml     sdk/dotnet/pulumi-plugin.json     sdk/dotnet/*.*.csproj     sdk/go/*/pulumi-plugin.json     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json
 
         git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
 


### PR DESCRIPTION
This includes some small tweaks necessary for onboarding pulumi-provider-boilerplate to ci-mgmt.

* Don't use a hardcoded "Pulumi" namespace. A provider can have a custom namespace which impacts the naming of `sdk/dotnet/Pulumi.*.csproj`.
* `sdk/dotnet/version.txt` is expected to change. We weren't ignoring this because relevant repos had already git-ignored it, but we should handle it the same as all the other version-sensitive files.

Related https://github.com/pulumi/pulumi-provider-boilerplate/pull/177.