### PR TITLE
Update verify-provider-release to v1.3.1

### DIFF
--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -79,6 +79,9 @@ jobs:
       - name: pulumi/esc-action
         uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
 
+      - name: pulumi/verify-provider-release
+        uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
+
       # GHA Utilities
 
       - name: actions-ecosystem/action-add-labels

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -397,6 +397,7 @@ type actionVersions struct {
 	FreeDiskSpace           string `yaml:"freeDiskSpace"`
 	ProviderVersionAction   string `yaml:"providerVersionAction"`
 	Codecov                 string `yaml:"codeCov"`
+	VerifyProviderRelease   string `yaml:"verifyProviderRelease"`
 }
 
 type toolVersions struct {
@@ -478,6 +479,8 @@ func loadDefaultConfig() (Config, error) {
 							config.ActionVersions.FreeDiskSpace = uses
 						case "pulumi/provider-version-action":
 							config.ActionVersions.ProviderVersionAction = uses
+						case "pulumi/verify-provider-release":
+							config.ActionVersions.VerifyProviderRelease = uses
 						case "codecov/codecov-action":
 							config.ActionVersions.Codecov = uses
 						}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -124,7 +124,7 @@ jobs:
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Nodejs }}#
       - name: Verify nodejs release
-        uses: pulumi/verify-provider-release@v1
+        uses: #{{ .Config.ActionVersions.VerifyProviderRelease }}#
         with:
           runtime: nodejs
           directory: #{{ .Config.ReleaseVerification.Nodejs }}#
@@ -133,7 +133,7 @@ jobs:
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Python }}#
       - name: Verify python release
-        uses: pulumi/verify-provider-release@v1
+        uses: #{{ .Config.ActionVersions.VerifyProviderRelease }}#
         with:
           runtime: python
           directory: #{{ .Config.ReleaseVerification.Python }}#
@@ -143,7 +143,7 @@ jobs:
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Dotnet }}#
       - name: Verify dotnet release
-        uses: pulumi/verify-provider-release@v1
+        uses: #{{ .Config.ActionVersions.VerifyProviderRelease }}#
         with:
           runtime: dotnet
           directory: #{{ .Config.ReleaseVerification.Dotnet }}#
@@ -152,7 +152,7 @@ jobs:
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Go }}#
       - name: Verify go release
-        uses: pulumi/verify-provider-release@v1
+        uses: #{{ .Config.ActionVersions.VerifyProviderRelease }}#
         if: inputs.skipGoSdk == false
         with:
           runtime: go

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -88,14 +88,14 @@ jobs:
           role-session-name: aws@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Verify nodejs release
-        uses: pulumi/verify-provider-release@v1
+        uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
           runtime: nodejs
           directory: examples/bucket
           provider: aws
           providerVersion: ${{ inputs.providerVersion }}
       - name: Verify python release
-        uses: pulumi/verify-provider-release@v1
+        uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
           runtime: python
           directory: examples/webserver-py
@@ -103,14 +103,14 @@ jobs:
           providerVersion: ${{ inputs.providerVersion }}
           packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
       - name: Verify dotnet release
-        uses: pulumi/verify-provider-release@v1
+        uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
           runtime: dotnet
           directory: examples/webserver-cs
           provider: aws
           providerVersion: ${{ inputs.providerVersion }}
       - name: Verify go release
-        uses: pulumi/verify-provider-release@v1
+        uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         if: inputs.skipGoSdk == false
         with:
           runtime: go


### PR DESCRIPTION
It was pinned to v1 meaning v1.0.0 and was not getting updated.

In addition make sure that subsequently it automatically gets updated through bot PRs to ci-mgmt.
