### PR TITLE
Expose ESC config to ci-mgmt.yaml

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -338,6 +338,10 @@ type Config struct {
 	// ModulePath tells the scripts where to find the go.mod entry point for the provider code.
 	// Historically this is defaulting to "provider" but for newer providers may be ".".
 	ModulePath string `yaml:"modulePath"`
+
+	// ESC allows the provider to extend our ESC integration, e.g. by using a
+	// custom environment or exporting specific variables.
+	ESC escConfig `yaml:"esc"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with
@@ -410,6 +414,14 @@ type toolVersions struct {
 	Python string `yaml:"python"`
 
 	PulumiCTL string `yaml:"pulumictl"`
+}
+
+type escConfig struct {
+	Enabled              bool     `yaml:"enabled"`
+	Environment          string   `yaml:"environment"`
+	Organization         string   `yaml:"organization"`
+	RequestedTokenType   string   `yaml:"requestedTokenType"`
+	EnvironmentVariables []string `yaml:"environmentVariables"`
 }
 
 type releaseVerification struct {

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -244,3 +244,10 @@ allowMissingDocs: true
 
 # Where the go.mod file for the skd lives
 sdkModuleDir: "sdk"
+
+esc:
+  enabled: false
+  environment: imports/github-secrets
+  organization: pulumi
+  requestedTokenType: urn:pulumi:token-type:access_token:organization
+  environmentVariables: []


### PR DESCRIPTION
This will make it possible for a provider to request their own ESC environment,
and it will enable us to move repo-specific secrets out of `.ci-mgmt.yaml`'s
`env:` key.

Refs https://github.com/pulumi/ci-mgmt/issues/1481
