### PR TITLE
Add a provider workflow to export repo secrets

### DIFF
--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -224,7 +224,7 @@ sdkModuleDir: "sdk"
 
 esc:
   enabled: false
-  environment: imports/github-secrets
+  environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
   organization: pulumi
   requestedTokenType: urn:pulumi:token-type:access_token:organization
   environmentVariables: []

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: #{{ .Config.ESC.Organization }}#
-          org-environment: #{{ .Config.ESC.Environment }}#
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/export-repo-secrets.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Export secrets to ESC
         uses: pulumi/esc-export-secrets-action@v1
         with:
-          organization: pulumi
-          org-environment: imports/github-secrets
+          organization: #{{ .Config.ESC.Organization }}#
+          org-environment: #{{ .Config.ESC.Environment }}#
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true
-          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+          oidc-requested-token-type: #{{ .Config.ESC.RequestedTokenType }}#
         env:
           GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/aws-native/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/aws/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/aws/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/aws/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/cloudflare/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/cloudflare/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/command/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/command/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/command/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/command/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/command/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/command/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/docker-build/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/docker-build/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/docker-build/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/docker/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/docker/.ci-mgmt.yaml
@@ -39,3 +39,6 @@ actions:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
 pulumiConvert: 1
 registryDocs: true
+
+esc:
+  environment: github-secrets/pulumi-pulumi-docker

--- a/provider-ci/test-providers/docker/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/docker/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/pulumi-pulumi-docker
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/docker/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/pulumi-pulumi-docker
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/eks/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/eks/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/eks/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/kubernetes/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/kubernetes/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/xyz/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [workflow_dispatch]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}

--- a/provider-ci/test-providers/xyz/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          org-environment: imports/github-secrets
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/provider-ci/test-providers/xyz/.github/workflows/export-repo-secrets.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true


### PR DESCRIPTION
This adds a new "Export secrets to ESC" workflow to our internal providers. The
workflow itself is copy-pasted from Pat's prior work. This workflow is
necessary in cases where the provider relies on repo-specific secrets. It may
need to be run at most once per provider, and we can remove this later when all
secrets have been migrated.

Confirmed working on docker-build:

```
❯ esc env get pulumi/github-secrets/pulumi-pulumi-docker-build

   Value

    {
      "environmentVariables": {
        ...
      }
    }

   Definition

    imports:
      - imports/github-secrets
    values:
      environmentVariables:
        CODECOV_TOKEN:
          ...
        DOCKER_HUB_PASSWORD:
          ...
```

Refs https://github.com/pulumi/ci-mgmt/issues/1481