### PR TITLE
Remove an unnecessary secret

### DIFF
--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
@@ -15,8 +15,6 @@ env:
 jobs:
   generate_coverage_data:
     continue-on-error: true
-    env:
-      COVERAGE_OUTPUT_DIR: ${{ secrets.COVERAGE_OUTPUT_DIR }}
     name: generate_coverage_data
     runs-on: #{{ .Config.Runner.Default }}#
     steps:
@@ -46,6 +44,8 @@ jobs:
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data
         run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov
       - name: Summarize Provider Coverage Results
         run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
       - name: Upload coverage data to S3
@@ -55,3 +55,5 @@ jobs:
           s3FullURI="s3://${{ secrets.S3_COVERAGE_BUCKET_NAME }}/summaries/${summaryName}"
 
           aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov

--- a/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
@@ -33,8 +33,6 @@ env:
 jobs:
   generate_coverage_data:
     continue-on-error: true
-    env:
-      COVERAGE_OUTPUT_DIR: ${{ secrets.COVERAGE_OUTPUT_DIR }}
     name: generate_coverage_data
     runs-on: ubuntu-latest
     steps:
@@ -62,6 +60,8 @@ jobs:
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data
         run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov
       - name: Summarize Provider Coverage Results
         run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
       - name: Upload coverage data to S3
@@ -71,3 +71,5 @@ jobs:
           s3FullURI="s3://${{ secrets.S3_COVERAGE_BUCKET_NAME }}/summaries/${summaryName}"
 
           aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov

--- a/provider-ci/test-providers/cloudflare/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/main-post-build.yml
@@ -32,8 +32,6 @@ env:
 jobs:
   generate_coverage_data:
     continue-on-error: true
-    env:
-      COVERAGE_OUTPUT_DIR: ${{ secrets.COVERAGE_OUTPUT_DIR }}
     name: generate_coverage_data
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +58,8 @@ jobs:
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data
         run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov
       - name: Summarize Provider Coverage Results
         run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
       - name: Upload coverage data to S3
@@ -69,3 +69,5 @@ jobs:
           s3FullURI="s3://${{ secrets.S3_COVERAGE_BUCKET_NAME }}/summaries/${summaryName}"
 
           aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov

--- a/provider-ci/test-providers/docker/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/main-post-build.yml
@@ -45,8 +45,6 @@ env:
 jobs:
   generate_coverage_data:
     continue-on-error: true
-    env:
-      COVERAGE_OUTPUT_DIR: ${{ secrets.COVERAGE_OUTPUT_DIR }}
     name: generate_coverage_data
     runs-on: ubuntu-latest
     steps:
@@ -73,6 +71,8 @@ jobs:
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data
         run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov
       - name: Summarize Provider Coverage Results
         run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
       - name: Upload coverage data to S3
@@ -82,3 +82,5 @@ jobs:
           s3FullURI="s3://${{ secrets.S3_COVERAGE_BUCKET_NAME }}/summaries/${summaryName}"
 
           aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
+        env:
+          COVERAGE_OUTPUT_DIR: ${{ runner.temp }}/cov


### PR DESCRIPTION
There's nothing special about this directory, and it's more work than necessary to handle this using ESC.

`${{ runner.temp }}` is tied to the lifecycle of the job, so it is stable for the duration of `generate_coverage_data`.