### PR TITLE
Add an ESC shim action

### DIFF
--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -335,6 +335,8 @@ func toYAML(v interface{}) (string, error) {
 	return strings.TrimSuffix(string(data), "\n"), nil
 }
 
+// renderESCStep generates either the real ESC action or our shim action which
+// re-exports the existing environment.
 func renderESCStep(v any) (string, error) {
 	config, ok := v.(Config)
 	if !ok {

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -318,7 +318,8 @@ func parseTemplate(fsys fs.FS, inPath string) (*template.Template, error) {
 	}
 
 	tmpl, err := template.New(inPath).Funcs(template.FuncMap{
-		"toYaml": toYAML,
+		"toYaml":        toYAML,
+		"renderEscStep": renderESCStep,
 	}).Funcs(sprig.FuncMap()).Delims("#{{", "}}#").Parse(string(inData))
 	if err != nil {
 		return nil, err
@@ -332,4 +333,45 @@ func toYAML(v interface{}) (string, error) {
 		return "", err
 	}
 	return strings.TrimSuffix(string(data), "\n"), nil
+}
+
+func renderESCStep(v any) (string, error) {
+	config, ok := v.(Config)
+	if !ok {
+		return "", fmt.Errorf("expected Config input, got %+v", v)
+	}
+
+	yaml := func(v any) (string, error) {
+		s, err := toYAML([]any{v})
+		return "\n" + s, err
+	}
+
+	if config.ESC.Enabled {
+		env := map[string]string{
+			"ESC_ACTION_OIDC_AUTH":                 "true",
+			"ESC_ACTION_OIDC_ORGANIZATION":         "pulumi",
+			"ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE": "urn:pulumi:token-type:access_token:organization",
+			"ESC_ACTION_ENVIRONMENT":               config.ESC.Environment,
+		}
+		if len(config.ESC.EnvironmentVariables) > 0 {
+			env["ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES"] = strings.Join(config.ESC.EnvironmentVariables, ",\n")
+
+		}
+		step := map[string]any{
+			"name": "Fetch secrets from ESC",
+			"id":   "esc-secrets",
+			"uses": "pulumi/esc-action@v1",
+			"env":  env,
+		}
+		return yaml(step)
+	}
+
+	// If ESC is disabled, we use a shim action which pipes environment
+	// variables to the action's outputs. This way our steps stay the same
+	// regardless of whether ESC is enabled or not.
+	return yaml(map[string]any{
+		"name": "Map environment to ESC outputs",
+		"id":   "esc-secrets",
+		"uses": "./.github/actions/esc-action",
+	})
 }

--- a/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/action.yaml
+++ b/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/action.yaml
@@ -1,0 +1,14 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+#{{ if not .Config.ESC.Enabled -}}#
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"
+#{{- end }}#

--- a/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/action.yaml
+++ b/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/action.yaml
@@ -5,10 +5,8 @@ description: |
   instead modify those steps to consume their secrets from this step's outputs.
   Then, later, we can replace this action with esc-action to actually load
   secrets from ESC.
-#{{ if not .Config.ESC.Enabled -}}#
 inputs: {}
 outputs: {}
 runs:
   using: "node20"
   main: "index.js"
-#{{- end }}#

--- a/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/index.js
+++ b/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/index.js
+++ b/provider-ci/internal/pkg/templates/internal/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/aws-native/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/aws-native/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/aws-native/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/aws-native/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/aws-native/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/aws-native/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/aws/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/aws/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/aws/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/aws/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/aws/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/aws/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/cloudflare/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/cloudflare/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/cloudflare/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/cloudflare/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/cloudflare/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/command/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/command/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/command/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/command/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/command/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/command/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/docker-build/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/docker-build/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/docker-build/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/docker-build/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/docker-build/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/docker-build/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/docker/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/docker/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/docker/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/docker/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/docker/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/docker/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/eks/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/eks/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/eks/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/eks/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/eks/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/eks/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/kubernetes/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/kubernetes/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/kubernetes/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/kubernetes/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();

--- a/provider-ci/test-providers/xyz/.github/actions/esc-action/action.yaml
+++ b/provider-ci/test-providers/xyz/.github/actions/esc-action/action.yaml
@@ -1,0 +1,12 @@
+name: "Load secrets"
+description: |
+  This is a temporary action which assists with our migration to ESC. Instead
+  of surrounding every step that references secrets with an "if ESC" block, we
+  instead modify those steps to consume their secrets from this step's outputs.
+  Then, later, we can replace this action with esc-action to actually load
+  secrets from ESC.
+inputs: {}
+outputs: {}
+runs:
+  using: "node20"
+  main: "index.js"

--- a/provider-ci/test-providers/xyz/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/xyz/.github/actions/esc-action/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+
+for (const [name, value] of Object.entries(process.env)) {
+  const file = process.env["GITHUB_OUTPUT"];
+  var stream = fs.createWriteStream(file, { flags: "a" });
+
+  try {
+    stream.write(`${name}=${value}\n`);
+  } catch (err) {
+    console.log(`error: failed to set output for ${name}: ${err.message}`);
+  }
+
+  stream.end();
+}

--- a/provider-ci/test-providers/xyz/.github/actions/esc-action/index.js
+++ b/provider-ci/test-providers/xyz/.github/actions/esc-action/index.js
@@ -1,14 +1,14 @@
 const fs = require("fs");
 
-for (const [name, value] of Object.entries(process.env)) {
-  const file = process.env["GITHUB_OUTPUT"];
-  var stream = fs.createWriteStream(file, { flags: "a" });
+const file = process.env["GITHUB_OUTPUT"];
+var stream = fs.createWriteStream(file, { flags: "a" });
 
+for (const [name, value] of Object.entries(process.env)) {
   try {
     stream.write(`${name}=${value}\n`);
   } catch (err) {
     console.log(`error: failed to set output for ${name}: ${err.message}`);
   }
-
-  stream.end();
 }
+
+stream.end();


### PR DESCRIPTION
This adds a small actions which has the same "interface" as ESC, but
which works with our existing CI environments. The action is trivial and
implemented as vanilla JavaScript to eliminate packaging pitfalls. (Only
JavaScript actions support the dynamic outputs we need.)

The action takes the CI job's environment and makes it available as an
output on the step, in the same way we will eventually consume secrets
as outputs from the esc-action step.

A new template method, `renderESCStep`, is also introduced which allows
us to toggle between the shim action and the actual ESC action. This
will allow us to roll out ESC gradually, and without needing to
introduce ESC conditionals around all of our steps.

This is a no-op. A subsequent PR will actually consume the new action.

Refs https://github.com/pulumi/ci-mgmt/issues/1481