### PR TITLE
Remove sumologic

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
+++ b/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
@@ -98,7 +98,6 @@ assignees: ''
 - [ ] [snowflake](https://github.com/pulumi/pulumi-snowflake)
 - [ ] [splunk](https://github.com/pulumi/pulumi-splunk)
 - [ ] [spotinst](https://github.com/pulumi/pulumi-spotinst)
-- [ ] [sumologic](https://github.com/pulumi/pulumi-sumologic)
 - [ ] [tailscale](https://github.com/pulumi/pulumi-tailscale)
 - [ ] [vault](https://github.com/pulumi/pulumi-vault)
 - [ ] [venafi](https://github.com/pulumi/pulumi-venafi)

--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -73,7 +73,6 @@
     "snowflake",
     "splunk",
     "spotinst",
-    "sumologic",
     "tailscale",
     "terraform",
     "terraform-module",


### PR DESCRIPTION
We no longer support this provider: https://github.com/pulumi/pulumi-sumologic/issues/653. It should be removed from automation.
