### PR TITLE
Sketch an experimental job to update Java everywhere

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -1,0 +1,86 @@
+name: update-java
+
+description: Update pulumi/pulumi-java used in all providers to a target version.
+
+permissions: write-all # Equivalent to default permissions plus id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      pulumi-java-version:
+        description: Desired version of pulumi/pulumi-java to ugprade to.
+        required: true
+        type: string
+
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-ci-mgmt
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
+
+jobs:
+
+  generate-providers-list:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@cf5b30703ffd5ad60cc3a880c09b3a9592b9372d # v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - id: get-providers
+        run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"
+        working-directory: provider-ci
+    outputs:
+      providers: ${{ steps.get-providers.outputs.providers }}
+
+  update-java:
+    needs: generate-providers-list
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # GitHub recommends only issuing 1 API request per second, and never
+      # concurrently.  For more information, see:
+      # https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
+      max-parallel: 1
+      matrix:
+        provider: ${{ fromJson(needs.generate-providers-list.outputs.providers ) }}
+
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@cf5b30703ffd5ad60cc3a880c09b3a9592b9372d # v1
+
+      - name: Checkout provider sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: pulumi/pulumi-${matrix.provider}
+          path: provider
+
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: pulumi/pulumictl
+
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v4
+
+      - name: "Set up git identity: name"
+        run: git config --global user.name '${{ github.actor }}'
+        shell: bash
+
+      - name: Upgrade Java
+        shell: bash
+        env:
+          P: pulumi/pulumi-${{matrix.provider}}
+          V: ${{inputs.pulumi-java-version}}
+        run: |
+          cd provider
+          upgrade-provider "$P" --kind=java --java-version="$V"
+
+      - name: Sleep to prevent hitting secondary rate limits
+        run: sleep 1


### PR DESCRIPTION
This job is intended to help with https://github.com/pulumi/ci-mgmt/issues/1611 rollout. 

It is currently experimental and a few follow-up PRs may be coming. With GHA it is difficult to test things out before they are on main. 