### PR TITLE
Compact JSON

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           V: ${{ inputs.pulumi-java-version }}
         run: |
-          INPUTS_JSON=$(jq -n --arg v "$V" '{version: $v}')
+          INPUTS_JSON=$(jq -c -n --arg v "$V" '{version: $v}')
           echo "json=$INPUTS_JSON" >> "$GITHUB_OUTPUT"
       - name: pulumi-${{ matrix.provider }} main
         id: upgrade-on-main


### PR DESCRIPTION
Continuing to iterate on update-java job. This fix makes sure jq formats the JSON payload on one line, which fixes a bug where the payload would not pass.