### PR TITLE
Propagate GH_TOKEN

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-java.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-java.yml
@@ -23,6 +23,11 @@ permissions:
   pull-requests: write
 
 env:
+
+  # upgrade-provider calls into gh CLI tool to open PRs that uses GH_TOKEN env var, which is not obivous.
+  # setting this correctly makes sure the PR has the correct owner and permissions work as expected.
+  GH_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN || secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,5 +63,6 @@ jobs:
         env:
           V: ${{inputs.version}}
           REPO: ${{github.repository}}
+          GH_TOKEN: ${{env.GH_TOKEN}}
         run: |
           upgrade-provider "$REPO" --kind=java --java-version="$V"

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-java.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-java.yml
@@ -23,6 +23,11 @@ permissions:
   pull-requests: write
 
 env:
+
+  # upgrade-provider calls into gh CLI tool to open PRs that uses GH_TOKEN env var, which is not obivous.
+  # setting this correctly makes sure the PR has the correct owner and permissions work as expected.
+  GH_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN || secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,5 +63,6 @@ jobs:
         env:
           V: ${{inputs.version}}
           REPO: ${{github.repository}}
+          GH_TOKEN: ${{env.GH_TOKEN}}
         run: |
           upgrade-provider "$REPO" --kind=java --java-version="$V"

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-java.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-java.yml
@@ -23,6 +23,11 @@ permissions:
   pull-requests: write
 
 env:
+
+  # upgrade-provider calls into gh CLI tool to open PRs that uses GH_TOKEN env var, which is not obivous.
+  # setting this correctly makes sure the PR has the correct owner and permissions work as expected.
+  GH_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN || secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,5 +63,6 @@ jobs:
         env:
           V: ${{inputs.version}}
           REPO: ${{github.repository}}
+          GH_TOKEN: ${{env.GH_TOKEN}}
         run: |
           upgrade-provider "$REPO" --kind=java --java-version="$V"

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-java.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-java.yml
@@ -23,6 +23,11 @@ permissions:
   pull-requests: write
 
 env:
+
+  # upgrade-provider calls into gh CLI tool to open PRs that uses GH_TOKEN env var, which is not obivous.
+  # setting this correctly makes sure the PR has the correct owner and permissions work as expected.
+  GH_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN || secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,5 +63,6 @@ jobs:
         env:
           V: ${{inputs.version}}
           REPO: ${{github.repository}}
+          GH_TOKEN: ${{env.GH_TOKEN}}
         run: |
           upgrade-provider "$REPO" --kind=java --java-version="$V"

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-java.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-java.yml
@@ -23,6 +23,11 @@ permissions:
   pull-requests: write
 
 env:
+
+  # upgrade-provider calls into gh CLI tool to open PRs that uses GH_TOKEN env var, which is not obivous.
+  # setting this correctly makes sure the PR has the correct owner and permissions work as expected.
+  GH_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN || secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,5 +63,6 @@ jobs:
         env:
           V: ${{inputs.version}}
           REPO: ${{github.repository}}
+          GH_TOKEN: ${{env.GH_TOKEN}}
         run: |
           upgrade-provider "$REPO" --kind=java --java-version="$V"

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-java.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-java.yml
@@ -23,6 +23,11 @@ permissions:
   pull-requests: write
 
 env:
+
+  # upgrade-provider calls into gh CLI tool to open PRs that uses GH_TOKEN env var, which is not obivous.
+  # setting this correctly makes sure the PR has the correct owner and permissions work as expected.
+  GH_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN || secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,5 +63,6 @@ jobs:
         env:
           V: ${{inputs.version}}
           REPO: ${{github.repository}}
+          GH_TOKEN: ${{env.GH_TOKEN}}
         run: |
           upgrade-provider "$REPO" --kind=java --java-version="$V"


### PR DESCRIPTION
This attempts to address an issue that java update PRs have the wrong owner and do not trigger tests properly: https://github.com/pulumi/ci-mgmt/issues/1605#issuecomment-3081399781
