### PR TITLE
Add a github workflow to comment on stale provider bugs

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -1,0 +1,40 @@
+name: "Comment on stale issues"
+
+on:
+  schedule:
+  - cron: "46 4 * * *" # run once per day
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+      with:
+        issue-types: issues # only look at issues (ignore pull-requests)
+
+        # Setting messages to an empty string causes the automation to skip that category
+        ancient-issue-message: "Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?"
+        ancient-pr-message: ""
+        stale-issue-message: ""
+        stale-pr-message: ""
+
+        # These labels are required
+        stale-issue-label: awaiting-feedback # somewhat confusingly, this is also used for when labeling "ancient" issues
+        exempt-issue-labels: kind/enhancement,kind/task,kind/epic,kind/engineering, awaiting-upstream # only run on kind/bug for now, ignore awaiting-upstream too.
+        stale-pr-label: no-pr-activity # unused because we aren't processing PRs
+        exempt-pr-labels: awaiting-approval # unused because we aren't processing PRs
+        response-requested-label: response-requested # unused because we don't set a "stale-issue-message" above
+
+        # Issue timing
+        days-before-close: 10000 # this action lacks the option not to close, so just set this indefinitly far in the future
+        days-before-ancient: 180 # 6 months
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 2
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG


### PR DESCRIPTION
We've discussed this a few times, but never quite pulled the trigger. This picks up the last PR: [[DO NOT MERGE] Create stale_issues.yaml · pulumi-aws/5366](https://github.com/pulumi/pulumi-aws/pull/5366) which tested this workflow against AWS. For this PR, I've kept the logic identical to that test, just moving it to ci-mgmt and running it on a cron: 

The action is configured to look for kind/bug issues that have not been updated in the last and have fewer than 2 upvotes. It would comment on these issues with the text:
>  Unfortunately, it looks like this issue hasn't seen any updates in a while. If you're still experiencing this issue, could you leave a quick comment to let us know so we can prioritize it?

and add the awaiting-feedback label. If a non-pulumi user replies, the issue will be bumped back into the triage queue using the usual automation. If no one replies, these issues will eventually show up in our "stale awaiting feedback" query on the team dashboards so we can take one last look at them and decide if we should close them.

The workflow defaults to just doing a dry run and I've added a new config flag to turn off dryRun and comment/label the issues for real. (So we can roll this out gradually to provider repos or disable it for a single repo if needed.) 