### PR TITLE
Default to dryrun for stale issues workflow and add a config flag so we can roll it gradually

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -342,6 +342,9 @@ type Config struct {
 	// ESC allows the provider to extend our ESC integration, e.g. by using a
 	// custom environment or exporting specific variables.
 	ESC escConfig `yaml:"esc"`
+
+	// ActuallyCommentOnStaleIssues controls whether we comment on stale issues
+	ActuallyCommentOnStaleIssues bool `yaml:"actuallyCommentOnStaleIssues"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,8 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+
+        #{{- if not .Config.ActuallyCommentOnStaleIssues }}#
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true
+        #{{- end }}#

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -68,3 +68,4 @@ releaseVerification:
   dotnet: examples/webserver-cs
   go: examples/webserver-go
 autoMergeProviderUpgrades: false
+actuallyCommentOnStaleIssues: true

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -38,3 +38,5 @@ jobs:
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true


### PR DESCRIPTION
I thought I'd pushed this change before landing [Add a github workflow to comment on stale provider bugs · ci-mgmt/1633](https://github.com/pulumi/ci-mgmt/pull/1633), but I hadn't, so we blasted out a lot of comments at once. 😬 

This change will flip the stale issues workflow to dry-run for all providers, so we can try again with the gradual approach. 