### PR TITLE
Remove Extra Mapping and Missing Mapping Errors from config

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -68,11 +68,6 @@ type Config struct {
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22fail-on-missing-mapping%3A%22&type=code
 	FailOnMissingMapping bool `yaml:"fail-on-missing-mapping"`
 
-	// FailOnExtraMapping sets PULUMI_EXTRA_MAPPING_ERROR in resync-build and
-	// defaults to true. It is not used:
-	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22fail-on-extra-mapping%3A%22&type=code
-	FailOnExtraMapping bool `yaml:"fail-on-extra-mapping"`
-
 	// PublishRegistry decides if create_docs_build happens during release This
 	// can be overridden to false to not publish updates. This is disabled in 5
 	// repos:

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -63,11 +63,6 @@ type Config struct {
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22providerDefaultBranch%3A%22&type=code
 	ProviderDefaultBranch string `yaml:"providerDefaultBranch"`
 
-	// FailOnMissingMapping sets PULUMI_MISSING_MAPPING_ERROR in the
-	// resync-build workflow. Used in alicloud only:
-	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22fail-on-missing-mapping%3A%22&type=code
-	FailOnMissingMapping bool `yaml:"fail-on-missing-mapping"`
-
 	// PublishRegistry decides if create_docs_build happens during release This
 	// can be overridden to false to not publish updates. This is disabled in 5
 	// repos:

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -51,8 +51,6 @@ providerDefaultBranch: master
 # Sets PULUMI_MISSING_MAPPING_ERROR in resync-build
 # Used in alicloud only: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22fail-on-missing-mapping%3A%22&type=code
 fail-on-missing-mapping: true
-# Not used: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22fail-on-extra-mapping%3A%22&type=code
-fail-on-extra-mapping: true
 
 # publishRegistry decides if create_docs_build happens during release
 # This can be overridden to false to not publish updates.

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -48,10 +48,6 @@ lint: true
 # Currently set in around 17 repos: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22providerDefaultBranch%3A%22&type=code
 providerDefaultBranch: master
 
-# Sets PULUMI_MISSING_MAPPING_ERROR in resync-build
-# Used in alicloud only: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22fail-on-missing-mapping%3A%22&type=code
-fail-on-missing-mapping: true
-
 # publishRegistry decides if create_docs_build happens during release
 # This can be overridden to false to not publish updates.
 # This is disabled in 5 repos: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22publishRegistry%3A%22&type=code


### PR DESCRIPTION
These configs have been orphaned with regard to provider Workflows.

They do not exist in the bridge.

This pull request cleans up the references. Note there was a claim that pulumi-alicloud uses this setting: it is also orphaned there.

Closes https://github.com/pulumi/ci-mgmt/issues/1634.
