### PR TITLE
Don't require mise to test ci-mgmt locally

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -51,9 +51,6 @@ test-provider/%: bin/provider-ci $(ACTIONLINT)
 	cp -r test-providers/$(PROVIDER_NAME) bin/test-provider
 	cd bin/test-provider/$(PROVIDER_NAME) && git init
 	cd bin/test-provider/$(PROVIDER_NAME) && ../../../$(ACTIONLINT) -config-file ../../../../.github/actionlint.yaml
-	# Experimental mise flag required to support building golang binaries (e.g. pulumictl)
-	mise settings experimental=true
-	cd bin/test-provider/$(PROVIDER_NAME) && mise trust && mise install && mise env
 
 # Fetch the latest .ci-mgmt.yaml from the provider repositories ready for testing.
 update-provider-configs:

--- a/provider-ci/internal/pkg/templates/mise/mise.toml
+++ b/provider-ci/internal/pkg/templates/mise/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-#{{trimSuffix ".x" .Config.ToolVersions.Java }}#'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '#{{ trimSuffix ".x" .Config.ToolVersions.Gradle }}#'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/acme/mise.toml
+++ b/provider-ci/test-providers/acme/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/aws-native/mise.toml
+++ b/provider-ci/test-providers/aws-native/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/aws/mise.toml
+++ b/provider-ci/test-providers/aws/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/cloudflare/mise.toml
+++ b/provider-ci/test-providers/cloudflare/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/command/mise.toml
+++ b/provider-ci/test-providers/command/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/docker-build/mise.toml
+++ b/provider-ci/test-providers/docker-build/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/docker/mise.toml
+++ b/provider-ci/test-providers/docker/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/eks/mise.toml
+++ b/provider-ci/test-providers/eks/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes-cert-manager/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes-coredns/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes/mise.toml
+++ b/provider-ci/test-providers/kubernetes/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/terraform-module/mise.toml
+++ b/provider-ci/test-providers/terraform-module/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/xyz/mise.toml
+++ b/provider-ci/test-providers/xyz/mise.toml
@@ -14,3 +14,6 @@ java = 'corretto-11'
 pulumi = 'latest'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
 gradle = '7.6'
+
+[settings]
+experimental = true # Required for Go binaries (e.g. pulumictl).


### PR DESCRIPTION
We'd like to keep mise strictly opt-in for now, but it's currently required to test ci-mgmt locally.

This PR:
* Adds the experimental flag to provider mise files, since those actually install pulumictl.
* Removes mise from the local test target.

We still have an issue where golangci-lint isn't setup correctly but I'll fix that in a followup.