### PR TITLE
Fix prerequisite permissions

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/main.yml
@@ -4,6 +4,9 @@ env:
 #{{ .Config.Env | toYaml | indent 2 }}#
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/nightly-test.yml
@@ -5,6 +5,9 @@ env:
 #{{ .Config.Env | toYaml | indent 2 }}#
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerelease.yml
@@ -5,6 +5,9 @@ env:
 #{{ .Config.Env | toYaml | indent 2 }}#
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -26,6 +26,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: #{{ .Config.Runner.Prerequisites }}#
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/release.yml
@@ -13,6 +13,9 @@ env:
 #{{ .Config.Env | toYaml | indent 2 }}#
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -19,6 +19,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -20,6 +20,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -41,6 +41,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -25,6 +25,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -22,6 +22,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -22,6 +22,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -23,6 +23,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -44,6 +44,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -28,6 +28,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -21,6 +21,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -22,6 +22,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -43,6 +43,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -27,6 +27,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -34,6 +34,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -35,6 +35,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -56,6 +56,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -40,6 +40,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/eks/.github/workflows/master.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/master.yml
@@ -26,6 +26,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/eks/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerelease.yml
@@ -27,6 +27,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -48,6 +48,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/eks/.github/workflows/release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/release.yml
@@ -32,6 +32,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/master.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/master.yml
@@ -20,6 +20,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerelease.yml
@@ -21,6 +21,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -42,6 +42,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/release.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/release.yml
@@ -26,6 +26,9 @@ env:
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/xyz/.github/workflows/main.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/main.yml
@@ -21,6 +21,9 @@ env:
   XYZ_REGION: us-west-2
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/xyz/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerelease.yml
@@ -22,6 +22,9 @@ env:
   XYZ_REGION: us-west-2
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -43,6 +43,9 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       version: ${{ steps.provider-version.outputs.version }}
     steps:

--- a/provider-ci/test-providers/xyz/.github/workflows/release.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/release.yml
@@ -27,6 +27,9 @@ env:
   XYZ_REGION: us-west-2
 jobs:
   prerequisites:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:


### PR DESCRIPTION
On Formal's org (and presumably other orgs out there), the default GitHub CI token permissions do not include commenting on PRs, which breaks CI. It's fixable by editing the yaml file, but that's an autogenerated file, so ideally this should be fixed in the CI generator.