### PR TITLE
Remove SLACK_WEBHOOK_URL secret from the global environment

### DIFF
--- a/provider-ci/internal/pkg/templates/aws-native/.github/workflows/cf2pulumi-release.yml
+++ b/provider-ci/internal/pkg/templates/aws-native/.github/workflows/cf2pulumi-release.yml
@@ -17,7 +17,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/internal/pkg/templates/aws-native/.github/workflows/nightly-sdk-generation.yml
+++ b/provider-ci/internal/pkg/templates/aws-native/.github/workflows/nightly-sdk-generation.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -120,3 +119,5 @@ jobs:
         author_name: Failure during automated SDK generation
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -247,6 +246,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: #{{ if eq .Config.Provider "command" }}#ubuntu-latest#{{ else }}#pulumi-ubuntu-8core#{{ end }}#
@@ -409,6 +410,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -636,6 +639,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: #{{ if eq .Config.Provider "aws-native" }}#macos-latest#{{ else
       }}#ubuntu-latest#{{ end }}#
@@ -704,6 +709,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -786,6 +793,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 #{{- if .Config.Lint }}#
   lint:
     runs-on: ubuntu-latest

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -236,6 +235,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: #{{ if eq .Config.Provider "command" }}#ubuntu-latest#{{ else }}#pulumi-ubuntu-8core#{{ end }}#
@@ -395,6 +396,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: #{{ if eq .Config.Provider "command" }}#ubuntu-latest#{{ else
       }}#pulumi-ubuntu-8core#{{ end }}#
@@ -604,6 +607,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: #{{ if eq .Config.Provider "aws-native" }}#macos-latest#{{ else
       }}#ubuntu-latest#{{ end }}#
@@ -672,6 +677,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -754,6 +761,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/pull-request.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -236,6 +235,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: #{{ if eq .Config.Provider "command" }}#ubuntu-latest#{{ else
@@ -397,6 +398,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: #{{ if eq .Config.Provider "command" }}#ubuntu-latest#{{ else
       }}#pulumi-ubuntu-8core#{{ end }}#
@@ -606,6 +609,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: #{{ if eq .Config.Provider "aws-native" }}#macos-latest#{{ else
       }}#ubuntu-latest#{{ end }}#
@@ -674,6 +679,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -756,6 +763,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -252,6 +251,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -415,6 +416,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -621,6 +624,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -212,6 +211,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -363,6 +364,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -509,6 +512,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: macos-latest
     needs: test
@@ -560,6 +565,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -642,3 +649,5 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/cf2pulumi-release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/cf2pulumi-release.yml
@@ -17,7 +17,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/nightly-sdk-generation.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/nightly-sdk-generation.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -121,3 +120,5 @@ jobs:
         author_name: Failure during automated SDK generation
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -204,6 +203,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -354,6 +355,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -481,6 +484,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: macos-latest
     needs: test
@@ -532,6 +537,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -614,6 +621,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/aws-native/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -204,6 +203,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -354,6 +355,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -481,6 +484,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: macos-latest
     needs: test
@@ -532,6 +537,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -614,6 +621,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -220,6 +219,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -374,6 +375,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -505,6 +508,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/aws-native/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -158,6 +157,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
@@ -305,6 +306,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -451,6 +454,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -511,6 +516,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -593,6 +600,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -150,6 +149,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
@@ -296,6 +297,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -423,6 +426,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -483,6 +488,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -565,6 +572,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/command/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/command/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -150,6 +149,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
@@ -296,6 +297,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -423,6 +426,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -483,6 +488,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -565,6 +572,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -166,6 +165,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -316,6 +317,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -447,6 +450,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/command/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/command/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -206,6 +205,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -353,6 +354,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -509,6 +512,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -567,6 +572,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -649,6 +656,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -198,6 +197,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -344,6 +345,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -481,6 +484,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -539,6 +544,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -621,6 +628,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/docker-build/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -198,6 +197,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -344,6 +345,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -481,6 +484,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -539,6 +544,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -621,6 +628,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -214,6 +213,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -364,6 +365,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -505,6 +508,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/docker-build/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -199,6 +198,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -348,6 +349,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -486,6 +489,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -546,6 +551,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -628,6 +635,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -458,6 +461,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -518,6 +523,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -600,6 +607,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -458,6 +461,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -518,6 +523,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -600,6 +607,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -207,6 +206,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -359,6 +360,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -482,6 +485,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -199,6 +198,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -348,6 +349,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -486,6 +489,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -546,6 +551,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -628,6 +635,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -458,6 +461,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -518,6 +523,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -600,6 +607,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -458,6 +461,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -518,6 +523,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -600,6 +607,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -207,6 +206,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -359,6 +360,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -482,6 +485,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -199,6 +198,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -348,6 +349,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -487,6 +490,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -547,6 +552,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -629,6 +636,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -459,6 +462,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -519,6 +524,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -601,6 +608,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -459,6 +462,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -519,6 +524,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -601,6 +608,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -207,6 +206,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -359,6 +360,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -483,6 +486,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -201,6 +200,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -348,6 +349,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -528,6 +531,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -588,6 +593,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -670,6 +677,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -193,6 +192,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -500,6 +503,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -560,6 +565,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -642,6 +649,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -193,6 +192,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -339,6 +340,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -500,6 +503,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -560,6 +565,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -642,6 +649,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -209,6 +208,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -359,6 +360,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -521,6 +524,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
@@ -32,7 +32,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -191,6 +190,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -338,6 +339,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release
@@ -469,6 +472,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -527,6 +532,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -609,6 +616,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -183,6 +182,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -329,6 +330,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -441,6 +444,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -499,6 +504,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -581,6 +588,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/pull-request.yml
@@ -14,7 +14,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
@@ -24,7 +24,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -183,6 +182,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -329,6 +330,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -441,6 +444,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish:
     runs-on: ubuntu-latest
     needs: test
@@ -499,6 +504,8 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
@@ -581,6 +588,8 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -199,6 +198,8 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -349,6 +350,8 @@ jobs:
         author_name: Failure while building SDKs
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -465,6 +468,8 @@ jobs:
         author_name: Failure in SDK tests
         fields: repo,commit,author,action
         status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/weekly-pulumi-update.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/weekly-pulumi-update.yml
@@ -16,7 +16,6 @@ env:
   PYPI_USERNAME: __token__
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
This is only used by the `8398a7/action-slack` steps, so we only need to expose it in those places.

Refs #1481.