### PR TITLE
Gradle v4 redux

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -799,8 +799,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -808,10 +812,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -801,8 +801,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -810,10 +814,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -659,8 +659,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -668,10 +672,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -659,8 +659,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -668,10 +672,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -610,8 +610,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -619,10 +623,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -610,8 +610,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -619,10 +623,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -666,8 +666,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -675,10 +679,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -666,8 +666,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -675,10 +679,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -645,8 +645,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -654,10 +658,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -645,8 +645,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -654,10 +658,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -645,8 +645,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -654,10 +658,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -645,8 +645,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -654,10 +658,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -646,8 +646,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -655,10 +659,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -646,8 +646,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -655,10 +659,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -687,8 +687,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -696,10 +700,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -687,8 +687,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -696,10 +700,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
@@ -626,8 +626,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -635,10 +639,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
@@ -626,8 +626,12 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Publish Java SDK
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      with:
+        gradle-version: "7.6"
+    - name: Publish Java SDK
+      run: gradle -p ./sdk/java publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
@@ -635,10 +639,6 @@ jobs:
         SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
         PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk


### PR DESCRIPTION
A follow-up to https://github.com/pulumi/ci-mgmt/pull/1656

Updates the publish tasks to use the gradle command, since the setup-gradle action doesn't support it.

Also updates the publish tasks to use Gradle 7.6 for consistency.