### PR TITLE
Respect PULUMI_API when generating access token

### DIFF
--- a/provider-ci/internal/pkg/templates/aws-native/.github/workflows/nightly-sdk-generation.yml
+++ b/provider-ci/internal/pkg/templates/aws-native/.github/workflows/nightly-sdk-generation.yml
@@ -46,9 +46,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -101,9 +101,10 @@ jobs:
       id: generate_pulumi_token
       uses: #{{ .Config.ActionVersions.ESCAuth }}#
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: #{{ .Config.ActionVersions.ESCAction }}#
       env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -83,9 +83,10 @@ jobs:
         id: generate_pulumi_token
         uses: #{{ .Config.ActionVersions.ESCAuth }}#
         with:
-          organization: pulumi
+          organization: ${{ env.PULUMI_TEST_OWNER || moolumi }}
           requested-token-type: urn:pulumi:token-type:access_token:organization
           export-environment-variables: false
+          cloud-url: ${{ env.PULUMI_API }}
       # workaround for https://github.com/pulumi/esc-action/issues/10
       - name: Install esc on Windows
         if: ${{ matrix.runner == 'windows-latest' }}

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -211,9 +211,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -538,9 +539,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -887,9 +889,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
       env:
@@ -967,9 +970,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Destroy test infra
       run: ./scripts/ci-cluster-destroy.sh ${{
         needs.build-test-cluster.outputs.stack-name }}

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -200,9 +200,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -508,9 +509,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -934,9 +936,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
       env:
@@ -1014,9 +1017,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Destroy test infra
       run: ./scripts/ci-cluster-destroy.sh ${{
         needs.build-test-cluster.outputs.stack-name }}

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -216,9 +216,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -517,9 +518,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -177,9 +177,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -474,9 +475,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/nightly-sdk-generation.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/nightly-sdk-generation.yml
@@ -47,9 +47,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -169,9 +169,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -446,9 +447,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -185,9 +185,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -470,9 +471,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -416,9 +416,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -388,9 +388,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -412,9 +412,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -462,9 +462,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -434,9 +434,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -458,9 +458,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/docker/.github/workflows/test.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/test.yml
@@ -79,9 +79,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/eks/.github/workflows/test.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/test.yml
@@ -99,9 +99,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -467,9 +467,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -760,9 +761,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
       env:
@@ -829,9 +831,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Destroy test infra
       run: ./scripts/ci-cluster-destroy.sh ${{
         needs.build-test-cluster.outputs.stack-name }}

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -439,9 +439,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:
@@ -807,9 +808,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
       env:
@@ -876,9 +878,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Destroy test infra
       run: ./scripts/ci-cluster-destroy.sh ${{
         needs.build-test-cluster.outputs.stack-name }}

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -455,9 +455,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
@@ -51,9 +51,10 @@ jobs:
       id: generate_pulumi_token
       uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
       with:
-        organization: pulumi
+        organization: ${{ env.PULUMI_TEST_OWNER || 'pulumi' }}
         requested-token-type: urn:pulumi:token-type:access_token:organization
         export-environment-variables: false
+        cloud-url: ${{ env.PULUMI_API }}
     - name: Export AWS Credentials
       uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
       env:


### PR DESCRIPTION
#1655 failed to fix p-k because the provider is hard-coded to expect a token for the moolumi org. So let's update the step to respect the cloud URL and test owner.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/3774.