### PR TITLE
Generate registry docs on appropriate targets

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -70,8 +70,8 @@ only_build: build
 prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
-generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
-build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}#
+generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
+build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -50,8 +50,8 @@ only_build: build
 prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema build_registry_docs
-generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
-build_sdks: build_nodejs build_python build_dotnet build_go build_java
+generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java build_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -50,8 +50,8 @@ only_build: build
 prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema build_registry_docs
-generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
-build_sdks: build_nodejs build_python build_dotnet build_go build_java
+generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java build_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 


### PR DESCRIPTION
This pull request addresses an oversight, where the generating of registry docs (the top-level provider landing page, under `docs/_index.md`) did not happen on the Make targets that `upgrade-provider` calls, resulting in issues such as https://github.com/pulumi/pulumi-docker/issues/1343.

Fixes #1667.
