### PR TITLE
Disable registry publishing for provider-boilerplate

### DIFF
--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.ci-mgmt.yaml
@@ -5,5 +5,6 @@ providerDefaultBranch: main
 providerVersion: github.com/pulumi/pulumi-provider-boilerplate/provider.Version
 parallel: 3
 sdkModuleDir: sdk/go/pulumi-provider-boilerplate
+publishRegistry: false
 envOverride:
   FOO: BAR # TODO: https://github.com/pulumi/ci-mgmt/issues/1583


### PR DESCRIPTION
The `provider-boilerplate` repository is a template and should not be published to the public registry. This was causing build failures in registry PRs like pulumi/registry#8481 with the error "no content files found for package, provider-boilerplate" because the package lacks the required documentation content.

The failure occurred in the registry CI build: https://github.com/pulumi/registry/actions/runs/17285449853/job/49061784042

While pulumi/pulumi-provider-boilerplate#308 set `publishRegistry` to `false` in the actual provider repository, the ci-mgmt system reads configuration from this repository's `test-providers` directory. The `publishRegistry` flag controls whether the `create_docs_build` job runs during releases, which dispatches to the registry repository to generate documentation builds.

This change prevents `pulumi-bot` from continuing to create registry PRs for `provider-boilerplate` despite the intended configuration.