### PR TITLE
Pass GITHUB_TOKEN to prepare_local_workspace

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -69,6 +69,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #{{- if .Config.Actions.PreBuild }}#
 #{{ .Config.Actions.PreBuild | toYaml | indent 4 }}#
 #{{- end }}#

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -68,6 +68,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate schema
       run: make schema
     - name: Build provider binary

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -79,6 +79,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate schema
       run: make schema
     - name: Build provider binary

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -70,6 +70,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate schema
       run: make schema
     - name: Build registry docs

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -83,6 +83,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate schema
       run: make schema
     - name: Build registry docs

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -83,6 +83,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate schema
       run: make schema
     - name: Build provider binary

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -63,6 +63,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build provider binary
       run: make provider
     - name: Unit-test provider code

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -68,6 +68,8 @@ jobs:
         tools: go, pulumictl, pulumicli, schema-tools
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate schema
       run: make schema
     - name: Build provider binary


### PR DESCRIPTION
We pass GITHUB_TOKEN to other instances of `make prepare_local_workspace` but missed this one, which can lead to rate limiting errors.