### PR TITLE
Pass credentials to tests

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -150,18 +150,18 @@ jobs:
       working-directory: provider
       run: go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#{{ .Config | renderLocalEnv | indent 8 }}#
     #{{- end }}#
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd #{{ .Config.TestFolder }}# && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#{{ .Config | renderLocalEnv | indent 8 }}#
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -run TestPulumiExamples -parallel 4 .
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#{{ .Config | renderLocalEnv | indent 8 }}#
 #{{- else }}#
 #{{- if .Config.Actions.PreTest }}#
 #{{ .Config.Actions.PreTest | toYaml | indent 4 }}#


### PR DESCRIPTION
The canary providers didn't catch this because they don't require secrets as part of their tests, but some providers like Tailscale, cloudflare, etc. do.