### PR TITLE
Pass credentials to the verify release step

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -133,6 +133,7 @@ jobs:
           providerVersion: ${{ inputs.providerVersion }}
         env:
           NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+#{{ .Config | renderLocalEnv | indent 10 }}#
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Python }}#
       - name: Verify python release
@@ -143,6 +144,8 @@ jobs:
           provider: #{{ .Config.Provider }}#
           providerVersion: ${{ inputs.providerVersion }}
           packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
+        env:
+#{{ .Config | renderLocalEnv | indent 10 }}#
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Dotnet }}#
       - name: Verify dotnet release
@@ -152,6 +155,8 @@ jobs:
           directory: #{{ .Config.ReleaseVerification.Dotnet }}#
           provider: #{{ .Config.Provider }}#
           providerVersion: ${{ inputs.providerVersion }}
+        env:
+#{{ .Config | renderLocalEnv | indent 10 }}#
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Go }}#
       - name: Verify go release
@@ -162,5 +167,7 @@ jobs:
           directory: #{{ .Config.ReleaseVerification.Go }}#
           provider: #{{ .Config.Provider }}#
           providerVersion: ${{ inputs.providerVersion }}
+        env:
+#{{ .Config | renderLocalEnv | indent 10 }}#
 #{{- end }}#
 #{{- end }}#

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -102,6 +102,7 @@ jobs:
           providerVersion: ${{ inputs.providerVersion }}
         env:
           NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify python release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -110,6 +111,8 @@ jobs:
           provider: aws
           providerVersion: ${{ inputs.providerVersion }}
           packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify dotnet release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -117,6 +120,8 @@ jobs:
           directory: examples/webserver-cs
           provider: aws
           providerVersion: ${{ inputs.providerVersion }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify go release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         if: inputs.skipGoSdk == false
@@ -125,3 +130,5 @@ jobs:
           directory: examples/webserver-go
           provider: aws
           providerVersion: ${{ inputs.providerVersion }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
@@ -83,3 +83,4 @@ jobs:
           providerVersion: ${{ inputs.providerVersion }}
         env:
           NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some providers run a small program as part of the verify release workflow. That program might need credentials, so we can pass the same environment we use for tests to it.

Fixes https://github.com/pulumi/pulumi-azure/issues/3276.
Refs https://github.com/pulumi/ci-mgmt/issues/1481.