### PR TITLE
Cleanup Javagen migration

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -81,46 +81,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -315,13 +315,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -76,46 +76,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -256,13 +256,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -96,46 +96,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -260,13 +260,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -87,46 +87,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -262,13 +262,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -100,46 +100,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -267,13 +267,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -100,46 +100,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -256,13 +256,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -85,46 +85,6 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
-      - name: Commit Java SDK changes for migration to pulumi package gen-sdk
-        if: failure() && steps.worktreeClean.outcome == 'failure' && matrix.language == 'java' && contains(github.actor, 'pulumi-bot') && github.event_name == 'pull_request'
-        shell: bash
-        run: >
-          git diff --quiet -- sdk/java && echo "no changes to sdk/java" && exit
-
-          git config --global user.email "bot@pulumi.com"
-
-          git config --global user.name "pulumi-bot"
-
-          # Stash local changes and check out the PR's branch directly.
-
-          git stash
-
-          git fetch
-
-          git checkout "origin/$HEAD_REF"
-
-          # Apply and add our changes, but don't commit any files we expect to
-
-          # always change due to versioning.
-
-          git stash pop
-
-          git add sdk/java
-
-          rm .pulumi-java-gen.version
-
-          git add .pulumi-java-gen.version
-
-          git commit -m "Commit Java changes for pulumi package sdk-gen"
-
-          # Push with pulumi-bot credentials to trigger a re-run of the
-          # workflow. https://github.com/orgs/community/discussions/25702
-
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
-        # head_ref is untrusted so it's recommended to pass via env var to
-        # avoid injections.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -256,13 +256,6 @@ upstream: .make/upstream
 	@touch $@
 .PHONY: upstream
 
-bin/pulumi-java-gen: PULUMI_JAVA_VERSION := $(shell cat .pulumi-java-gen.version)
-bin/pulumi-java-gen: PLAT := $(shell go version | sed -En "s/go version go.* (.*)\/(.*)/\1-\2/p")
-bin/pulumi-java-gen: PULUMI_JAVA_URL := "https://github.com/pulumi/pulumi-java/releases/download/v$(PULUMI_JAVA_VERSION)/pulumi-language-java-v$(PULUMI_JAVA_VERSION)-$(PLAT).tar.gz"
-bin/pulumi-java-gen:
-	wget -q -O - "$(PULUMI_JAVA_URL)" | tar -xzf - -C $(WORKING_DIR)/bin pulumi-java-gen
-	@touch bin/pulumi-language-java
-
 # To make an immediately observable change to .ci-mgmt.yaml:
 #
 # - Edit .ci-mgmt.yaml


### PR DESCRIPTION
This pull request removes the Java SDK commit step from SDKgen. All bridged providers have been moved over to use bridge javagen.

Additionally, we clean up the now-redundant check for the Javangen version in `bin`.


