### PR TITLE
Fix publish external providers

### DIFF
--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -435,12 +435,8 @@ func renderPublishEnv(v any) (string, error) {
 
 	env := map[string]string{}
 
-	if config.Organization == "pulumi" && !config.ESC.Enabled {
+	if !config.ESC.Enabled {
 		env = map[string]string{
-			"AWS_ACCESS_KEY_ID":     "${{ secrets.AWS_ACCESS_KEY_ID }}",
-			"AWS_SECRET_ACCESS_KEY": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-			"AWS_UPLOAD_ROLE_ARN":   "${{ secrets.AWS_UPLOAD_ROLE_ARN }}",
-			"CODECOV_TOKEN":         "${{ secrets.CODECOV_TOKEN }}",
 			"JAVA_SIGNING_KEY_ID":   "${{ secrets.JAVA_SIGNING_KEY_ID }}",
 			"JAVA_SIGNING_KEY":      "${{ secrets.JAVA_SIGNING_KEY }}",
 			"JAVA_SIGNING_PASSWORD": "${{ secrets.JAVA_SIGNING_PASSWORD }}",
@@ -448,10 +444,17 @@ func renderPublishEnv(v any) (string, error) {
 			"NUGET_PUBLISH_KEY":     "${{ secrets.NUGET_PUBLISH_KEY }}",
 			"OSSRH_PASSWORD":        "${{ secrets.OSSRH_PASSWORD }}",
 			"OSSRH_USERNAME":        "${{ secrets.OSSRH_USERNAME }}",
-			"PULUMI_BOT_TOKEN":      "${{ secrets.PULUMI_BOT_TOKEN }}",
 			"PYPI_API_TOKEN":        "${{ secrets.PYPI_API_TOKEN }}",
-			"RELEASE_BOT_ENDPOINT":  "${{ secrets.RELEASE_BOT_ENDPOINT }}",
-			"RELEASE_BOT_KEY":       "${{ secrets.RELEASE_BOT_KEY }}",
+		}
+
+		if config.Organization == "pulumi" {
+			env["AWS_SECRET_ACCESS_KEY"] = "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+			env["AWS_ACCESS_KEY_ID"] = "${{ secrets.AWS_ACCESS_KEY_ID }}"
+			env["AWS_UPLOAD_ROLE_ARN"] = "${{ secrets.AWS_UPLOAD_ROLE_ARN }}"
+			env["CODECOV_TOKEN"] = "${{ secrets.CODECOV_TOKEN }}"
+			env["PULUMI_BOT_TOKEN"] = "${{ secrets.PULUMI_BOT_TOKEN }}"
+			env["RELEASE_BOT_ENDPOINT"] = "${{ secrets.RELEASE_BOT_ENDPOINT }}"
+			env["RELEASE_BOT_KEY"] = "${{ secrets.RELEASE_BOT_KEY }}"
 		}
 	}
 

--- a/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST every Tuesday.
     - cron: 0 3 * * TUE
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -21,9 +21,17 @@ on:
 
 env:
   IS_PRERELEASE: ${{ inputs.isPrerelease }}
+  JAVA_SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
+  JAVA_SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
+  JAVA_SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+  OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST every Tuesday.
     - cron: 0 3 * * TUE
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -37,9 +37,17 @@ on:
         required: false
 
 env:
+  JAVA_SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
+  JAVA_SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
+  JAVA_SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+  OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/resync-build.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST every Tuesday.
     - cron: 0 3 * * TUE
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Fixes: #1738

In #1736, I changed some code so a set of environment variables was only added for Pulumi managed providers. In that set of environment variables, I missed these contain the secrets to publish to the various package registries.

I tweaked it now that these secrets are always set, but only more are added for Pulumi managed providers.

Tested manually on `pulumiverse/pulumi-grafana`:

* Before the fix: https://github.com/pulumiverse/pulumi-grafana/actions/runs/17937299375
* After the fix: https://github.com/pulumiverse/pulumi-grafana/actions/runs/17968917504