### PR TITLE
Install mise before syncing ci-mgmt for external providers.

### DIFF
--- a/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           # Persist credentials so pull-workflow-changes can push a new branch.
           persist-credentials: true
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Regenerate the workflow files via https://github.com/pulumi/ci-mgmt
         run: |
           make ci-mgmt

--- a/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           # Persist credentials so pull-workflow-changes can push a new branch.
           persist-credentials: true
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Regenerate the workflow files via https://github.com/pulumi/ci-mgmt
         run: |
           make ci-mgmt


### PR DESCRIPTION
Install mise before syncing ci-mgmt via this pull based workflow. Only used for external providers.

Before this fix, resync of ci-mgmt failed on `mise` not being installed:

https://github.com/pulumiverse/pulumi-scaleway/actions/runs/18045377938/job/51354747678#step:3:31