### PR TITLE
Fix some mise workflow issues

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/internal/pkg/templates/all/scripts/get-versions.sh
+++ b/provider-ci/internal/pkg/templates/all/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
@@ -86,10 +86,13 @@ jobs:
         #{{- end }}#
         persist-credentials: false
       #{{- .Config | renderEscStep | indent 4 }}#
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
+    - name: Setup mise
+      uses: jdx/mise-action@v3
       with:
-        tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_key: "mise-{{platform}}-{{file_hash}}"
+        # only saving the cache in the prerequisites job
+        cache_save: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: #{{ .Config.ActionVersions.UpgradeProviderAction }}#

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -55,10 +55,13 @@ jobs:
           # Persist credentials so upgrade-provider can push a new branch.
           persist-credentials: true
       #{{- .Config | renderEscStep | indent 6 }}#
-      - name: Setup tools
-        uses: ./.github/actions/setup-tools
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Install upgrade-provider
         run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash

--- a/provider-ci/test-providers/acme/.config/mise.toml
+++ b/provider-ci/test-providers/acme/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
@@ -80,10 +80,13 @@ jobs:
     - id: esc-secrets
       name: Map environment to ESC outputs
       uses: ./.github/actions/esc-action
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
+    - name: Setup mise
+      uses: jdx/mise-action@v3
       with:
-        tools: pulumictl, pulumicli, dotnet, go, nodejs, python
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_key: "mise-{{platform}}-{{file_hash}}"
+        # only saving the cache in the prerequisites job
+        cache_save: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@3c670a7cb92732324c8ccc17f7f9ef9dfca126d0 # v0.0.17

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -48,10 +48,13 @@ jobs:
       - id: esc-secrets
         name: Map environment to ESC outputs
         uses: ./.github/actions/esc-action
-      - name: Setup tools
-        uses: ./.github/actions/setup-tools
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          tools: pulumictl, pulumicli, dotnet, go, nodejs, python
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Install upgrade-provider
         run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash

--- a/provider-ci/test-providers/acme/scripts/get-versions.sh
+++ b/provider-ci/test-providers/acme/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/aws-native/scripts/get-versions.sh
+++ b/provider-ci/test-providers/aws-native/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -95,10 +95,13 @@ jobs:
       id: esc-secrets
       name: Fetch secrets from ESC
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
+    - name: Setup mise
+      uses: jdx/mise-action@v3
       with:
-        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_key: "mise-{{platform}}-{{file_hash}}"
+        # only saving the cache in the prerequisites job
+        cache_save: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@3c670a7cb92732324c8ccc17f7f9ef9dfca126d0 # v0.0.17

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -63,10 +63,13 @@ jobs:
         id: esc-secrets
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-      - name: Setup tools
-        uses: ./.github/actions/setup-tools
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Install upgrade-provider
         run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash

--- a/provider-ci/test-providers/aws/scripts/get-versions.sh
+++ b/provider-ci/test-providers/aws/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -92,10 +92,13 @@ jobs:
       id: esc-secrets
       name: Fetch secrets from ESC
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
+    - name: Setup mise
+      uses: jdx/mise-action@v3
       with:
-        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_key: "mise-{{platform}}-{{file_hash}}"
+        # only saving the cache in the prerequisites job
+        cache_save: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@3c670a7cb92732324c8ccc17f7f9ef9dfca126d0 # v0.0.17

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -60,10 +60,13 @@ jobs:
         id: esc-secrets
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-      - name: Setup tools
-        uses: ./.github/actions/setup-tools
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Install upgrade-provider
         run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash

--- a/provider-ci/test-providers/cloudflare/scripts/get-versions.sh
+++ b/provider-ci/test-providers/cloudflare/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/command/scripts/get-versions.sh
+++ b/provider-ci/test-providers/command/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/docker-build/scripts/get-versions.sh
+++ b/provider-ci/test-providers/docker-build/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -97,10 +97,13 @@ jobs:
       id: esc-secrets
       name: Fetch secrets from ESC
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
+    - name: Setup mise
+      uses: jdx/mise-action@v3
       with:
-        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_key: "mise-{{platform}}-{{file_hash}}"
+        # only saving the cache in the prerequisites job
+        cache_save: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@3c670a7cb92732324c8ccc17f7f9ef9dfca126d0 # v0.0.17

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -65,10 +65,13 @@ jobs:
         id: esc-secrets
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-      - name: Setup tools
-        uses: ./.github/actions/setup-tools
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Install upgrade-provider
         run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash

--- a/provider-ci/test-providers/docker/scripts/get-versions.sh
+++ b/provider-ci/test-providers/docker/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/eks/scripts/get-versions.sh
+++ b/provider-ci/test-providers/eks/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes-cert-manager/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes-cert-manager/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes-coredns/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes-coredns/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/scripts/get-versions.sh
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/terraform-module/scripts/get-versions.sh
+++ b/provider-ci/test-providers/terraform-module/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-bridge.yml
@@ -87,10 +87,13 @@ jobs:
       id: esc-secrets
       name: Fetch secrets from ESC
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
+    - name: Setup mise
+      uses: jdx/mise-action@v3
       with:
-        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        cache_key: "mise-{{platform}}-{{file_hash}}"
+        # only saving the cache in the prerequisites job
+        cache_save: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@3c670a7cb92732324c8ccc17f7f9ef9dfca126d0 # v0.0.17

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
@@ -55,10 +55,13 @@ jobs:
         id: esc-secrets
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
-      - name: Setup tools
-        uses: ./.github/actions/setup-tools
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_key: "mise-{{platform}}-{{file_hash}}"
+          # only saving the cache in the prerequisites job
+          cache_save: false
       - name: Install upgrade-provider
         run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash

--- a/provider-ci/test-providers/xyz/scripts/get-versions.sh
+++ b/provider-ci/test-providers/xyz/scripts/get-versions.sh
@@ -29,8 +29,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "PULUMI_VERSION=$raw_version"
-export PULUMI_VERSION=$raw_version
+echo "MISE_PULUMI_VERSION=$raw_version"
+export MISE_PULUMI_VERSION=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -46,5 +46,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "GO_VERSION=$go_version"
-export GO_VERSION=$go_version
+echo "MISE_GO_VERSION=$go_version"
+export MISE_GO_VERSION=$go_version


### PR DESCRIPTION
This PR fixes a couple of issues.

- Adds mise setup job to the upgrade-provider and upgrade-bridge jobs.
- Changes the env vars to have a `MISE_` prefix to not conflict with
  existing env vars.

Tested this on the `pulumi-tls` provider [here](https://github.com/pulumi/pulumi-tls/actions/runs/18098245541)