### PR TITLE
Rename mise env vars

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/internal/pkg/templates/all/scripts/get-versions.sh
+++ b/provider-ci/internal/pkg/templates/all/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/acme/.config/mise.toml
+++ b/provider-ci/test-providers/acme/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/acme/scripts/get-versions.sh
+++ b/provider-ci/test-providers/acme/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/aws-native/scripts/get-versions.sh
+++ b/provider-ci/test-providers/aws-native/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/aws/scripts/get-versions.sh
+++ b/provider-ci/test-providers/aws/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/cloudflare/scripts/get-versions.sh
+++ b/provider-ci/test-providers/cloudflare/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/command/scripts/get-versions.sh
+++ b/provider-ci/test-providers/command/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/docker-build/scripts/get-versions.sh
+++ b/provider-ci/test-providers/docker-build/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/docker/scripts/get-versions.sh
+++ b/provider-ci/test-providers/docker/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/eks/scripts/get-versions.sh
+++ b/provider-ci/test-providers/eks/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes-cert-manager/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes-cert-manager/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes-coredns/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes-coredns/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/kubernetes/scripts/get-versions.sh
+++ b/provider-ci/test-providers/kubernetes/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/scripts/get-versions.sh
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/terraform-module/scripts/get-versions.sh
+++ b/provider-ci/test-providers/terraform-module/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -8,7 +8,7 @@ _.source = "{{config_root}}/scripts/get-versions.sh"
 
 # Runtimes
 # TODO: we may not need `get_env` once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='MISE_GO_VERSION', default='latest') }}"
+go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20'
 python = '3.11.8'
 dotnet = '8.0'
@@ -16,7 +16,7 @@ dotnet = '8.0'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='MISE_PULUMI_VERSION', default='latest') }}"
+pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
 gradle = '7.6'

--- a/provider-ci/test-providers/xyz/scripts/get-versions.sh
+++ b/provider-ci/test-providers/xyz/scripts/get-versions.sh
@@ -34,8 +34,8 @@ if [[ -z "${raw_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_PULUMI_VERSION=$raw_version"
-export MISE_PULUMI_VERSION=$raw_version
+echo "PULUMI_VERSION_MISE=$raw_version"
+export PULUMI_VERSION_MISE=$raw_version
 
 # Prefer the toolchain directive if present, otherwise fall back to the `go` version line
 go_toolchain=$(awk '/^toolchain[[:space:]]+go[0-9]/{ print $2; exit }' "$gomod")
@@ -51,5 +51,5 @@ if [[ -z "${go_version:-}" ]]; then
   exit 1
 fi
 
-echo "MISE_GO_VERSION=$go_version"
-export MISE_GO_VERSION=$go_version
+echo "GO_VERSION_MISE=$go_version"
+export GO_VERSION_MISE=$go_version


### PR DESCRIPTION
Turns out that `MISE_` env vars [are
special](https://github.com/jdx/mise/discussions/6476) and will prevent
the version from being written to the lockfile (or from MISE_ENV from working)