### PR TITLE
Bump aws-actions/stale-issue-cleanup

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc #v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac #v7.1.0
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 


### PR DESCRIPTION
Recent unreleased commits have re-generated the action's dist.js, so let's see if that helps fix this failing job.

Refs https://github.com/pulumi/pulumi-aws/issues/5788.