### PR TITLE
Ignore mise.lock in `git-status-check`

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -94,6 +94,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -90,6 +90,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -106,6 +106,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -103,6 +103,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -108,6 +108,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -105,6 +105,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -98,6 +98,8 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+            **/mise.lock
+            **/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The


### PR DESCRIPTION
The mise.lock file is only updated when a machine first downloads a tool
version. If there is a cache on the machine, the lockfile is not updated
with the checksum entry. It also only adds a checksum entry for the arch
of the machine that is installing the tool. This means that sometimes CI
will update the mise.lock file and cause the git-status-check to fail.