### PR TITLE
Add MISE_ENV to entire test workflow

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
 #{{ .Config | renderGlobalEnv | indent 2 }}#
 
 jobs:

--- a/provider-ci/test-providers/acme/.github/workflows/test.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   AWS_REGION: us-west-2
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..

--- a/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/docker/.github/workflows/test.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
   ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7

--- a/provider-ci/test-providers/eks/.github/workflows/test.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   AWS_REGION: us-west-2
   DOTNET_VERSION: 6.x
   GO_VERSION: 1.21.x

--- a/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
   AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
   AWS_REGION: us-west-2

--- a/provider-ci/test-providers/xyz/.github/workflows/test.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  MISE_ENV: test
+
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget


### PR DESCRIPTION
I thought I had this in there, but I must have removed it when debugging
something. We need the env var to exist for the entire run, not just
when the tools are installed, otherwise mise will pick the wrong
versions when actually using the tools

Refs https://github.com/pulumi/ci-mgmt/issues/1727.