### PR TITLE
Always update mise.lock when running migrations

### DIFF
--- a/provider-ci/internal/pkg/migrations/create_mise_lock.go
+++ b/provider-ci/internal/pkg/migrations/create_mise_lock.go
@@ -8,23 +8,22 @@ import (
 	"strings"
 )
 
-// Need to create an initial mise.lock file
-type createMiseLock struct{}
+// Always update the mise.lock file when we update ci-mgmt
+type maintainMiseLock struct{}
 
-func (createMiseLock) Name() string {
-	return "Create an initial mise.lock"
+func (maintainMiseLock) Name() string {
+	return "Update mise.lock"
 }
-func (createMiseLock) ShouldRun(templateName string) bool {
+func (maintainMiseLock) ShouldRun(templateName string) bool {
 	return true
 }
-func (createMiseLock) Migrate(templateName, outDir string) error {
+func (maintainMiseLock) Migrate(templateName, outDir string) error {
 	miseLockPath := filepath.Join(outDir, ".config", "mise.lock")
 	_, err := os.Stat(miseLockPath)
-	if !os.IsNotExist(err) {
-		return nil
-	}
-	if _, err := os.Create(miseLockPath); err != nil {
-		return fmt.Errorf("error creating mise.lock: %w", err)
+	if os.IsNotExist(err) {
+		if _, err := os.Create(miseLockPath); err != nil {
+			return fmt.Errorf("error creating mise.lock: %w", err)
+		}
 	}
 	pulumiVersion, goVersion, err := getVersions(outDir)
 	if err != nil {

--- a/provider-ci/internal/pkg/migrations/migrations.go
+++ b/provider-ci/internal/pkg/migrations/migrations.go
@@ -22,7 +22,7 @@ func Migrate(templateName, outDir string) error {
 		updateToDotnet8{},
 		ignoreMiseLocal{},
 		migrateMiseConfig{},
-		createMiseLock{},
+		maintainMiseLock{},
 		maintainGolangciConfig{},
 	}
 	for i, migration := range migrations {


### PR DESCRIPTION
We need to figure out all the ways we need to be updating the mise.lock
file, but this is an easy first step. Whenever we update ci-mgmt, re-run
`mise install` which will update the lockfile and be checked in.

Refs https://github.com/pulumi/ci-mgmt/issues/1727.