### PR TITLE
Fix ignoring mise.lock in git-status-check

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -95,7 +95,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -91,7 +91,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -107,7 +107,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -104,7 +104,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -109,7 +109,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -106,7 +106,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -99,7 +99,9 @@ jobs:
             sdk/python/pyproject.toml
             sdk/java/build.gradle
             **/mise.lock
+            **/.config/mise.lock
             **/mise.*.lock
+            **/.config/mise.*.lock
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The


### PR DESCRIPTION
The library we use for `git-status-check` (picomatch) does not match
dotfiles by default unless a `.` is explicitly defined in the pattern