### PR TITLE
Fix comment permissions

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/pull-request.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/pull-request.yml
@@ -3,11 +3,17 @@
 env:
 #{{ .Config | renderGlobalEnv | indent 2 }}#
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: #{{ .Config.Runner.Default }}#
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: #{{ .Config.ActionVersions.PrComment }}#
@@ -17,6 +23,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
@@ -7,11 +7,17 @@ env:
   PULUMI_PROVIDER_AUTOMATION_TOKEN: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_TOKEN }}
   TF_APPEND_USER_AGENT: pulumi
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -21,6 +27,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
@@ -8,11 +8,17 @@ env:
   PULUMI_MISSING_DOCS_ERROR: "true"
   TF_APPEND_USER_AGENT: pulumi
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -22,6 +28,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
@@ -6,11 +6,17 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   TF_APPEND_USER_AGENT: pulumi
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: pulumi-ubuntu-8core
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -20,6 +26,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
@@ -18,11 +18,17 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   TF_APPEND_USER_AGENT: pulumi
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -32,6 +38,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/eks/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/pull-request.yml
@@ -15,11 +15,17 @@ env:
   PYTHON_VERSION: "3.9"
   TF_APPEND_USER_AGENT: pulumi
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -29,6 +35,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/pull-request.yml
@@ -16,11 +16,17 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -30,6 +36,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}

--- a/provider-ci/test-providers/xyz/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/pull-request.yml
@@ -8,11 +8,17 @@ env:
   TF_APPEND_USER_AGENT: pulumi
   XYZ_REGION: us-west-2
 
+name: Comment on community PRs
+on:
+  pull_request_target: {}
+
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
     name: comment-on-pr
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -22,6 +28,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-name: pull-request
-on:
-  pull_request_target: {}


### PR DESCRIPTION
I think I originally had this commenting as pulumi-bot which requires ESC for the token, but this doesn't work on forked PRs. We're already using the generated `GITHUB_TOKEN` so the ESC step is unnecessary.