### PR TITLE
Fix parameterized-go makefile

### DIFF
--- a/provider-ci/internal/pkg/templates/parameterized-go/Makefile
+++ b/provider-ci/internal/pkg/templates/parameterized-go/Makefile
@@ -157,7 +157,6 @@ renovate:
 .PHONY: renovate
 #{{- end }}#
 
-include scripts/plugins.mk
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.

--- a/provider-ci/test-providers/terraform-module/Makefile
+++ b/provider-ci/test-providers/terraform-module/Makefile
@@ -126,7 +126,6 @@ ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 .PHONY: ci-mgmt
 
-include scripts/plugins.mk
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.


### PR DESCRIPTION
Didn't realize that parameterized-go has a different Makefile than
`base`. Need to do the same migration here.