### PR TITLE
Stop automatic pull from ci-mgmt for external providers.

### DIFF
--- a/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
@@ -2,9 +2,6 @@
 name: "Resync Build Workflows"
 
 on:
-  schedule:
-    # 3 AM UTC ~ 8 PM PDT / 7 PM PST every Tuesday.
-    - cron: 0 3 * * TUE
   workflow_dispatch:
 
 permissions:

--- a/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
@@ -2,9 +2,6 @@
 name: "Resync Build Workflows"
 
 on:
-  schedule:
-    # 3 AM UTC ~ 8 PM PDT / 7 PM PST every Tuesday.
-    - cron: 0 3 * * TUE
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Since `ci-mgmt` isn't officially supported (yet) for external providers, lower the amount of issues reported by external parties by no longer automatically pulling in the `ci-mgmt` changes on a weekly basis.

This pull based sync is now only manually triggered.