### PR TITLE
Fix golangci-lint v2 migration

### DIFF
--- a/provider-ci/internal/pkg/migrations/maintain_golangci_config.go
+++ b/provider-ci/internal/pkg/migrations/maintain_golangci_config.go
@@ -36,9 +36,11 @@ func (maintainGolangciConfig) ShouldRun(_ string) bool {
 func (maintainGolangciConfig) Migrate(_ string, cwd string) error {
 	// JSON version output was introduced in v2.
 	cmd := exec.Command("golangci-lint", "version", "--json")
+	cmd.Dir = cwd
 	usingV2 := cmd.Run() == nil
 
 	if !usingV2 {
+		fmt.Printf("Skipping: already on golangci-lint v2")
 		return nil
 	}
 
@@ -62,6 +64,7 @@ func (maintainGolangciConfig) Migrate(_ string, cwd string) error {
 	}
 
 	cmd = exec.Command("golangci-lint", "migrate")
+	cmd.Dir = cwd
 	output, err := cmd.CombinedOutput()
 
 	if err != nil {


### PR DESCRIPTION
When we upgrade workflows on CI we don't run `generate` from the provider's repository, so the migrate step was failing to find the relevant `.golangci.yml`.

This fixes the issue by explicitly scoping the commands to `outDir`, which I guess is the normal pattern.

Example failure: https://github.com/pulumi/pulumi-vault/pull/877
Testing fix: https://github.com/pulumi/pulumi-vault/pull/879

NB: I considered changing ci-mgmt's update-workflows to just run `make ci-mgmt` inside the provider, but our native providers aren't guaranteed to have that target.