### PR TITLE
Replace `pulumi-java-gen` with `pulumi package gen-sdk`.

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -161,7 +161,7 @@ build_java: .make/build_java
 #{{- if or (eq .Config.Provider "eks") (eq .Config.Provider "awsx") (eq .Config.Provider "aws-apigateway") }}#
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/generate_java: PACKAGE_VERSION := $(PROVIDER_VERSION)
-.make/generate_java: .make/mise_install bin/pulumi-java-gen .make/schema
+.make/generate_java: .make/mise_install .make/schema
 .make/generate_java: | mise_env
 	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --language java --out sdk/
 	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -140,7 +140,7 @@ generate_java: .make/generate_java
 build_java: .make/build_java
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/generate_java: PACKAGE_VERSION := $(PROVIDER_VERSION)
-.make/generate_java: .make/mise_install bin/pulumi-java-gen .make/schema
+.make/generate_java: .make/mise_install .make/schema
 .make/generate_java: | mise_env
 	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --language java --out sdk/
 	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod


### PR DESCRIPTION
The non-deprecated way to generate Java SDKs is using the `pulumi package gen-sdk` command. This PR replaces `pulumi-java-gen` for most providers.

Steps to merge this:
 * [x] Run and verify `ci-mgmt` `Makefile` target in `eks`.
 * [x] Run and verify `ci-mgmt` `Makefile` target in `awsx`.
 * [x] Run and verify `ci-mgmt` `Makefile` target in `aws-apigateway`.

---

The only difference we will notice in the SDK generation once we merge the change are how the headers will look like:

```diff
-// *** WARNING: this file was generated by pulumi-java-gen. ***
+// *** WARNING: this file was generated by pulumi-language-java. ***
```