### PR TITLE
Use gradle 7.6.0

### DIFF
--- a/provider-ci/internal/pkg/migrations/migrate_cimgmt_to_mise.go
+++ b/provider-ci/internal/pkg/migrations/migrate_cimgmt_to_mise.go
@@ -40,7 +40,7 @@ java = 'corretto-11'
 pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = 'latest'
 "github:pulumi/schema-tools" = "latest"
-gradle = '7.6'
+gradle = '7.6.0'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 


### PR DESCRIPTION
As part of onboarding pulumi-std it's failing to grab 7.6
```
mise ERROR Failed to install aqua:gradle/gradle@7.6: 
     0: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/gradle/gradle-distributions/releases/tags/7.6)
     1: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/gradle/gradle-distributions/releases/tags/v7.6)
```

Using 7.6.0 fixes the problem.