### PR TITLE
Respect noSchema in native providers

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Make Kubernetes provider
       run: make k8sprovider
     #{{- end }}#
-    #{{- if and (ne .Config.Provider "command") (ne .Config.Provider "terraform") }}#
+    #{{- if not .Config.NoSchema }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-

--- a/provider-ci/test-providers/command/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/command/.ci-mgmt.yaml
@@ -6,6 +6,7 @@ pulumiVersionFile: .pulumi.version
 providerDefaultBranch: main
 parallel: 3
 timeout: 0.0000001
+noSchema: true # Disable schema check.
 envOverride:
   AWS_REGION: us-west-2
   PULUMI_API: https://api.pulumi-staging.io


### PR DESCRIPTION
We currently hard-code the terraform and command providers as opting-out of schema checks.

We already expose config to let providers do this themselves, and we respect it in bridged providers. Let's also respect it in native providers.

This unblocks https://github.com/pulumi/pulumi-std/pull/96 because that provider doesn't currently keep its schema in a standard place.

To be merged after:
* https://github.com/pulumi/pulumi-terraform/pull/891
* https://github.com/pulumi/pulumi-command/pull/1023