### PR TITLE
Move back `build` target to top of Makefile for `base`

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -59,23 +59,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -89,6 +76,20 @@ generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}##{{- 
 build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -39,23 +39,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -69,6 +56,20 @@ generate_sdks: generate_dotnet generate_go generate_nodejs generate_python
 build_sdks: build_dotnet build_go build_nodejs build_python
 install_sdks: install_dotnet_sdk install_go_sdk install_nodejs_sdk install_python_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -39,23 +39,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -69,6 +56,20 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -39,23 +39,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks build_registry_docs
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -69,6 +56,20 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -39,23 +39,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks build_registry_docs
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -69,6 +56,20 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -39,23 +39,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -69,6 +56,20 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -39,23 +39,10 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-# Installs all necessary tools with mise and records completion in a sentinel
-# file so dependent targets can participate in make's caching behaviour. The
-# environment is refreshed via an order-only prerequisite so it still runs on
-# every invocation without invalidating the sentinel.
-mise_install: .make/mise_install | mise_env
-
-.PHONY: mise_env
-mise_env:
-	@mise env -q  > /dev/null
-
-.make/mise_install:
-	@mise install -q
-	@touch $@
-
 # Build the provider and all SDKs and install ready for testing
 build: .make/mise_install provider build_sdks install_sdks
 build: | mise_env
+
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -69,6 +56,20 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks mise_install mise_env
+
+# Installs all necessary tools with mise and records completion in a sentinel
+# file so dependent targets can participate in make's caching behaviour. The
+# environment is refreshed via an order-only prerequisite so it still runs on
+# every invocation without invalidating the sentinel.
+mise_install: .make/mise_install | mise_env
+
+mise_env:
+	@mise env -q  > /dev/null
+
+.make/mise_install:
+	@mise install -q
+	@touch $@
+
 
 help:
 	@echo "Usage: make [target]"


### PR DESCRIPTION
Fixes #1825

From the Makefile manual:

> By default, the goal is the first target in the makefile (not counting
targets that start with a period). Therefore, makefiles are usually written so that the first target is for compiling the entire program or programs they describe.

When we introduced mise_install target on top of base/Makefile, we replaced the build target as goal.

## Testing

Checked out `test-providers` and verified they worked as before the `mise` change:
* [x] acme
* [x] aws
* [x] cloudflare
* [x] docker
* [x] eks
* [x] xyz