### PR TITLE
Preserve env in native composite actions

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/actions/download-provider/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/download-provider/action.yml
@@ -1,6 +1,9 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+#{{ .Config | renderGlobalEnv | indent 2 }}#
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/internal/pkg/templates/native/.github/actions/download-sdk/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/download-sdk/action.yml
@@ -1,9 +1,12 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+#{{ .Config | renderGlobalEnv | indent 2 }}#
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
@@ -1,6 +1,9 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+#{{ .Config | renderGlobalEnv | indent 2 }}#
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/aws-native/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/download-provider/action.yml
@@ -1,6 +1,10 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  AWS_REGION: us-west-2
+  PULUMI_API: https://api.pulumi-staging.io
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/aws-native/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/download-sdk/action.yml
@@ -1,9 +1,13 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  AWS_REGION: us-west-2
+  PULUMI_API: https://api.pulumi-staging.io
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
@@ -1,6 +1,10 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  AWS_REGION: us-west-2
+  PULUMI_API: https://api.pulumi-staging.io
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/command/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/download-provider/action.yml
@@ -1,6 +1,10 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  AWS_REGION: us-west-2
+  PULUMI_API: https://api.pulumi-staging.io
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/command/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/download-sdk/action.yml
@@ -1,9 +1,13 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  AWS_REGION: us-west-2
+  PULUMI_API: https://api.pulumi-staging.io
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
@@ -1,6 +1,10 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  AWS_REGION: us-west-2
+  PULUMI_API: https://api.pulumi-staging.io
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/docker-build/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/download-provider/action.yml
@@ -1,6 +1,21 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
+  ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
+  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  AWS_REGION: us-west-2
+  AZURE_LOCATION: westus
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-ci-gcp-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT: pulumi-ci-gcp-provider
+  GOOGLE_PROJECT_NUMBER: "895284651812"
+  GOOGLE_REGION: us-central1
+  GOOGLE_ZONE: us-central1-a
+  PULUMI_API: https://api.pulumi-staging.io
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/docker-build/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/download-sdk/action.yml
@@ -1,9 +1,24 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
+  ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
+  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  AWS_REGION: us-west-2
+  AZURE_LOCATION: westus
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-ci-gcp-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT: pulumi-ci-gcp-provider
+  GOOGLE_PROJECT_NUMBER: "895284651812"
+  GOOGLE_REGION: us-central1
+  GOOGLE_ZONE: us-central1-a
+  PULUMI_API: https://api.pulumi-staging.io
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
@@ -1,6 +1,21 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
+  ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
+  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  AWS_REGION: us-west-2
+  AZURE_LOCATION: westus
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-ci-gcp-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT: pulumi-ci-gcp-provider
+  GOOGLE_PROJECT_NUMBER: "895284651812"
+  GOOGLE_REGION: us-central1
+  GOOGLE_ZONE: us-central1-a
+  PULUMI_API: https://api.pulumi-staging.io
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/download-provider/action.yml
@@ -1,6 +1,15 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/download-sdk/action.yml
@@ -1,9 +1,18 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
@@ -1,6 +1,15 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/download-provider/action.yml
@@ -1,6 +1,15 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/download-sdk/action.yml
@@ -1,9 +1,18 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
@@ -1,6 +1,15 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/download-provider/action.yml
@@ -1,6 +1,15 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/download-sdk/action.yml
@@ -1,9 +1,18 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
@@ -1,6 +1,15 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/kubernetes/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/download-provider/action.yml
@@ -1,6 +1,16 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.64.8
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_TEST_OWNER: moolumi
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/kubernetes/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/download-sdk/action.yml
@@ -1,9 +1,19 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.64.8
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
@@ -1,6 +1,16 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  AWS_REGION: us-west-2
+  GOLANGCI_LINT_VERSION: v1.64.8
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: "637339343727"
+  PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_TEST_OWNER: moolumi
+
 inputs:
   cache:
     description: Enable caching

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/download-provider/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/download-provider/action.yml
@@ -1,6 +1,12 @@
 name: Download Provider Binary
 description: Downloads the provider binary artifact and restores executable permissions
 
+env:
+  PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
+  PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  TF_APPEND_USER_AGENT: pulumi
+
 runs:
   using: "composite"
   steps:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/download-sdk/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/download-sdk/action.yml
@@ -1,9 +1,15 @@
 name: Download SDK
 description: Downloads and extracts SDK artifacts for a specific language
 
+env:
+  PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
+  PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  TF_APPEND_USER_AGENT: pulumi
+
 inputs:
   language:
-    description: 'The SDK language to download (nodejs, python, dotnet, java)'
+    description: "The SDK language to download (nodejs, python, dotnet, java)"
     required: true
 
 runs:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
@@ -1,6 +1,12 @@
 name: Setup Tools
 description: Installs all tools (Go, Node, Python, .NET, Java, Pulumi, etc.) using mise
 
+env:
+  PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
+  PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  TF_APPEND_USER_AGENT: pulumi
+
 inputs:
   cache:
     description: Enable caching


### PR DESCRIPTION
Factoring these steps out into composite actions had an implicit side effect where those steps stopped getting global env vars. This is probably contributing to the k8s failure because it no longer sees the correct value for `PULUMI_LOCAL_NUGET`.

This PR restores the env vars for all of the composite actions to guarantee we go back to prior behavior. We might not need these env vars in all of the actions, and we can look into that later.

Tested here but still failing, something else must be going on.
https://github.com/pulumi/pulumi-kubernetes/pull/3959