### PR TITLE
Set GOTOOLCHAIN to `auto` in Verify Release Workflows

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -126,6 +126,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       #{{- end }}#
       #{{- end }}#
       - name: Install Pulumi CLI

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -100,6 +100,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -104,6 +104,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -108,6 +108,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -120,6 +120,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -111,6 +111,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/verify-release.yml
@@ -118,6 +118,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:

--- a/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
@@ -104,6 +104,9 @@ jobs:
             sdk/*.sum
             *.sum
           cache: true
+      - name: Set Go Toolchain to auto explicitly
+        run: |
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Install Pulumi CLI
         uses: pulumi/actions@d7ceb0215da5a14ec84f50b703365ddf0194a9c8 # v6
         with:


### PR DESCRIPTION
This pull request is a hotfix for https://github.com/pulumi/pulumi-tls/issues/888.

In all other workflows, we allow for Mise to install the Go version but we decided to keep the legacy implementation where we allow for the setup-go job to install the version instead.
Setup-go shipped a change https://github.com/actions/setup-go/pull/460 where the gotoolchain is now installed using `local` not `auto` and this keeps the verify-release workflow from installing a Go version other than  the one set in the tool version.

Update: It turns out that v1.22.x is not enough: https://github.com/pulumi/pulumi-gcp/actions/runs/19448883749/job/55655199413#step:17:54 

> Error: exec: go: go.mod requires go >= 1.23.3 (running go 1.21.13; GOTOOLCHAIN=local)

so rather than bumping the Go version, this pull request sets the go toolchain to `auto` so the workflow downloads it as before.
