### PR TITLE
mise: Increase fetch timeouts

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -63,6 +63,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -54,6 +54,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/license.yml
@@ -20,6 +20,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -65,6 +65,8 @@ jobs:
     #{{- end }}#
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -47,6 +47,8 @@ jobs:
     #{{- .Config | renderEscStep | indent 4 }}#
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -143,6 +145,8 @@ jobs:
     #{{- .Config | renderEscStep | indent 4 }}#
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
@@ -88,6 +88,8 @@ jobs:
       #{{- .Config | renderEscStep | indent 4 }}#
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -57,6 +57,8 @@ jobs:
       #{{- .Config | renderEscStep | indent 6 }}#
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/external/.github/workflows/resync-build.yml
@@ -20,6 +20,8 @@ jobs:
           persist-credentials: true
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/copilot-setup-steps.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
@@ -42,6 +42,8 @@ jobs:
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -52,6 +52,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -50,6 +50,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/license.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/license.yml
@@ -24,6 +24,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -57,6 +57,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
       uses: ./.github/actions/esc-action
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -127,6 +129,8 @@ jobs:
       uses: ./.github/actions/esc-action
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
@@ -20,6 +20,8 @@ jobs:
           persist-credentials: true
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/test.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
@@ -82,6 +82,8 @@ jobs:
       uses: ./.github/actions/esc-action
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -50,6 +50,8 @@ jobs:
         uses: ./.github/actions/esc-action
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -67,6 +67,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -66,6 +66,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/copilot-setup-steps.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -25,6 +25,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
@@ -53,6 +53,8 @@ jobs:
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -72,6 +72,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -58,6 +58,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,6 +149,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -97,6 +97,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -65,6 +65,8 @@ jobs:
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -66,6 +66,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -63,6 +63,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/copilot-setup-steps.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -23,6 +23,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/main-post-build.yml
@@ -50,6 +50,8 @@ jobs:
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -69,6 +69,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -55,6 +55,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -143,6 +145,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -94,6 +94,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -62,6 +62,8 @@ jobs:
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -58,6 +58,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -68,6 +68,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/copilot-setup-steps.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -35,6 +35,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -35,6 +35,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/main-post-build.yml
@@ -62,6 +62,8 @@ jobs:
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -74,6 +74,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -67,6 +67,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,6 +157,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/test.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -99,6 +99,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -67,6 +67,8 @@ jobs:
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -58,6 +58,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -65,6 +65,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/license.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/license.yml
@@ -32,6 +32,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/lint.yml
@@ -32,6 +32,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -71,6 +71,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -64,6 +64,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -152,6 +154,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/eks/.github/workflows/test.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
@@ -15,6 +15,8 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         cache_save: ${{ inputs.cache }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -52,6 +52,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/license.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/license.yml
@@ -33,6 +33,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/lint.yml
@@ -33,6 +33,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -60,6 +60,8 @@ jobs:
         set-env: 'PROVIDER_VERSION'
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/publish.yml
@@ -65,6 +65,8 @@ jobs:
       uses: ./.github/actions/esc-action
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_provider.yml
@@ -58,6 +58,8 @@ jobs:
           tag: v2.1.5-procursus2
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -58,6 +58,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/copilot-setup-steps.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/license.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/license.yml
@@ -25,6 +25,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
         persist-credentials: false
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/main-post-build.yml
@@ -52,6 +52,8 @@ jobs:
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -64,6 +64,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -145,6 +147,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/test.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       uses: jdx/mise-action@v3
       env:
         MISE_ENV: test
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-bridge.yml
@@ -89,6 +89,8 @@ jobs:
       uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
     - name: Setup mise
       uses: jdx/mise-action@v3
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
         version: 2025.11.6
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
@@ -57,6 +57,8 @@ jobs:
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
         uses: jdx/mise-action@v3
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
           version: 2025.11.6
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've noticed that mise will often flake due to hitting the default 10s fetch timeout. Increasing it to 30s caused a flaky build to go green, so let's make that the new default.

(For some reason this is almost always with Python.)

Refs https://github.com/pulumi/ci-mgmt/issues/1727