### PR TITLE
mise: Install tools when updating workflows

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -95,7 +95,8 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
         with:
-          version: 2025.11.6
+          # Latest working version. See https://github.com/jdx/mise/discussions/6781
+          version: 2025.10.16
           cache: false
           working_directory: pulumi-${{ inputs.provider_name }}
       - name: Generate workflow files into pulumi-${{ inputs.provider_name }}


### PR DESCRIPTION
We should have the provider's toolchain available when generating workflows to more closely match the behavior we expect to see (i.e. when running locally).

The version of golangci-lint is used to determine whether you get v1 or v2 lint config, for example.