### PR TITLE
Relax 'worktree clean' check for Renovate PRs

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -96,6 +96,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -146,6 +146,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -92,6 +92,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -133,6 +133,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -108,6 +108,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -105,6 +105,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -96,6 +96,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -142,6 +142,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -110,6 +110,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -107,6 +107,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -136,6 +136,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -136,6 +136,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -136,6 +136,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -139,6 +139,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -130,6 +130,10 @@ jobs:
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
           sdk/java/build.gradle
+      # This worktree check is a safeguard against someone forgetting to
+      # re-build and commit locally, but we handle that commit automatically in
+      # the case of dependency bumps.
+      continue-on-error: ${{ contains(github.actor, 'renovate') }}
     - name: Commit SDK changes for Renovate
       if: failure() && steps.worktreeClean.outcome == 'failure' &&
         contains(github.actor, 'renovate') && github.event_name ==

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -100,6 +100,10 @@ jobs:
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
             sdk/java/build.gradle
+        # This worktree check is a safeguard against someone forgetting to
+        # re-build and commit locally, but we handle that commit automatically
+        # in the case of dependency bumps.
+        continue-on-error: ${{ contains(github.actor, 'renovate') }}
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The


### PR DESCRIPTION
Relevant to two internal conversations.

* https://pulumi.slack.com/archives/C09ANN8P0N4/p1765223435588129?thread_ts=1765220623.591769&cid=C09ANN8P0N4 -- wherein we started generating a new `.gitattributes` file.
* https://pulumi.slack.com/archives/C0A2UPPKCC8/p1765054040354419 -- wherein a dependency bump made changes to `schema.json`.

In both of these cases the PR was automated but blocked because we found the worktree to be dirty after rebuilding. But in both cases we were only bumping dependencies, so we can assume any changes to generated artifacts is due to upstream.

This PR relaxes the worktree-is-clean check to allow for changes on Renovate PRs. Immediately after those changes are detected we commit them.