### PR TITLE
mise: Use in ci-mgmt's update workflow

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -53,16 +53,6 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           path: ci-mgmt
-      - name: Install ci-mgmt's mise
-        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
-        with:
-          version: 2025.12.1
-          working_directory: ci-mgmt
-      - name: Setup Go cache
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
-        with:
-          cache: true
-          cache-dependency-path: ci-mgmt/provider-ci/go.sum
       - name: Initialize submodule in pulumi-${{ inputs.provider_name }}
         run: cd pulumi-${{ inputs.provider_name }} && make upstream && cd ..
         continue-on-error: true
@@ -71,12 +61,12 @@ jobs:
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/cleanup-artifacts.yml || echo "not found"
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/pull_request.yml || echo "not found"
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/master.yml || echo "not found"
-      - name: Install provider's golangci-lint
+      - name: Install mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
         with:
           version: 2025.12.1
-          install_args: golangci-lint
-          cache: false
+          install_args: go golangci-lint
+          cache_key_prefix: mise-v0-${{ inputs.provider_name}}-
           working_directory: pulumi-${{ inputs.provider_name }}
       - name: Generate workflow files into pulumi-${{ inputs.provider_name }}
         working-directory: ci-mgmt/provider-ci


### PR DESCRIPTION
Simplify (and speed up) the setup of our update-workflows jobs. The only tools we need to install are the provider's version of go and golangci-lint -- and we can cache those.

Confirmed working [here](https://github.com/pulumi/ci-mgmt/actions/runs/20113027371/job/57715271370).

As a reminder, eventually we want to get rid of this in favor of something providers invoke, instead of ci-mgmt invoking whatever workflows the provider happens to have committed.