### PR TITLE
Also accept codegen changes to schema

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -120,7 +120,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/#{{ .Config.Provider }}#/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -177,7 +177,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/#{{ .Config.Provider }}#/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -340,7 +340,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/#{{ .Config.Provider }}#/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -117,7 +117,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/acme/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -165,7 +165,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/aws-native/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -328,7 +328,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/aws-native/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -133,7 +133,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/aws/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -130,7 +130,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/cloudflare/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -128,7 +128,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/command/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -273,7 +273,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/command/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -174,7 +174,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/docker-build/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -325,7 +325,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/docker-build/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -135,7 +135,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/docker/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -132,7 +132,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/eks/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -168,7 +168,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes-cert-manager/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -316,7 +316,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes-cert-manager/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -168,7 +168,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes-coredns/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -316,7 +316,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes-coredns/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -168,7 +168,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes-ingress-nginx/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -316,7 +316,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes-ingress-nginx/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -171,7 +171,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -317,7 +317,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/kubernetes/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -162,7 +162,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/provider-boilerplate/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \
@@ -310,7 +310,7 @@ jobs:
 
         git stash pop
 
-        git add sdk
+        git add sdk provider/cmd/provider-boilerplate/schema.json
 
         git reset sdk/python/*/pulumi-plugin.json \
             sdk/python/pyproject.toml \

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -125,7 +125,7 @@ jobs:
           # Apply and add our changes, but don't commit any files we expect to
           # always change due to versioning.
           git stash pop
-          git add sdk
+          git add sdk provider/cmd/xyz/schema.json
           git reset \
               sdk/python/*/pulumi-plugin.json \
               sdk/python/pyproject.toml \


### PR DESCRIPTION
Some more followup to https://github.com/pulumi/ci-mgmt/pull/1903. The schema should also be allowed to change when we bump upstream codegen.