### PR TITLE
Clean disk space before linting

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/lint.yml
@@ -18,6 +18,15 @@ jobs:
       pull-requests: write
       id-token: write # For ESC secrets.
     steps:
+#{{- if .Config.FreeDiskSpaceBeforeTest }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: #{{ .Config.ActionVersions.FreeDiskSpace }}#
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+#{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.ActionVersions.Checkout }}#
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -24,6 +24,13 @@ jobs:
       pull-requests: write
       id-token: write # For ESC secrets.
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -22,6 +22,13 @@ jobs:
       pull-requests: write
       id-token: write # For ESC secrets.
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:


### PR DESCRIPTION
Linting compiles our code and tests, so we should free up disk space if `freeDiskSpaceBeforeTest` was specified. This primarily affects azure and cloudflare (and maybe aws?) who have had disk issues.