### PR TITLE
Bump stale-issue-cleanup job

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -1,6 +1,7 @@
 name: "Comment on stale issues"
 
 on:
+  workflow_dispatch: {}
   schedule:
   - cron: "46 4 * * *" # run once per day
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@5650b49bcd757a078f6ca06c373d7807b773f9bc # v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@891b9c362427a77b24fec2892b7e942146208c6b
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 


### PR DESCRIPTION
* Update the job to the latest (unreleased) distribution, in case that might resolve the errors we've been seeing with it.
* Make the workflow manually runnable for testing.