### PR TITLE
Remove javaGenVersion

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -38,11 +38,6 @@ type Config struct {
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22plugins%3A%22&type=code
 	Plugins []plugin `yaml:"plugins"`
 
-	// JavaGenVersion ensures a specific javaGen version is used during
-	// upgrades if set. Set for 2 providers:
-	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22javaGenVersion%3A%22&type=code
-	JavaGenVersion string `yaml:"javaGenVersion"`
-
 	// UpstreamProviderOrg is optional and used in the bridge upgrade config.
 	// Only set for 4 providers:
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22upstreamProviderOrg%3A%22&type=code

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
@@ -113,9 +113,6 @@ jobs:
         automerge: ${{ inputs.automerge }}
         target-bridge-version: ${{ inputs.target-bridge-version }}
         target-pulumi-version: ${{ inputs.target-pulumi-version }}
-        #{{- if .Config.JavaGenVersion }}#
-        target-java-version: #{{ .Config.JavaGenVersion }}#
-        #{{- end }}#
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
         pr-title-prefix: ${{ inputs.pr-title-prefix }}

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -107,9 +107,6 @@ jobs:
           automerge: #{{ .Config.AutoMergeProviderUpgrades }}#
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: #{{ .Config.AllowMissingDocs }}#
-          #{{- if .Config.JavaGenVersion }}#
-          target-java-version: #{{ .Config.JavaGenVersion }}#
-          #{{- end }}#
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Comment on upgrade issue if automated PR failed

--- a/provider-ci/internal/pkg/templates/internal-bridged/.upgrade-config.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.upgrade-config.yml
@@ -11,6 +11,3 @@ upstream-provider-org: #{{ .Config.UpstreamProviderOrg }}#
 #{{- end }}#
 pulumi-infer-version: true
 remove-plugins: true
-#{{- if .Config.JavaGenVersion }}#
-javaVersion: "#{{ .Config.JavaGenVersion }}#"
-#{{- end }}#


### PR DESCRIPTION
This is no longer needed since https://github.com/pulumi/ci-mgmt/issues/1636 now has all providers under ci-mgmt generating Java via the CLI.

There's only [one use](https://github.com/search?q=org%3Apulumi%20javagenversion%20path%3A.ci-mgmt.yaml&type=code) of it in a deprecated repo, so it's safe to remove.