### PR TITLE
Flag upgrade-provider build failures

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -98,7 +98,6 @@ jobs:
       - name: Call upgrade provider action
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
-        continue-on-error: true
         uses: #{{ .Config.ActionVersions.UpgradeProviderAction }}#
         with:
           kind: provider
@@ -112,19 +111,4 @@ jobs:
           #{{- end }}#
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Comment on upgrade issue if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
-          gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Fail workflow if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "Failed to create automated PR"
-          exit 1
-
 #{{ end -}}#

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -90,7 +90,6 @@ jobs:
       - name: Call upgrade provider action
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
-        continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@e247104aede3eb4641f48c8ad0ea9de9346f2457 # v0.0.18
         with:
           kind: provider
@@ -101,18 +100,3 @@ jobs:
           allow-missing-docs: true
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Comment on upgrade issue if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
-          gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Fail workflow if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "Failed to create automated PR"
-          exit 1
-

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -105,7 +105,6 @@ jobs:
       - name: Call upgrade provider action
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
-        continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@e247104aede3eb4641f48c8ad0ea9de9346f2457 # v0.0.18
         with:
           kind: provider
@@ -116,18 +115,3 @@ jobs:
           allow-missing-docs: false
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Comment on upgrade issue if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
-          gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Fail workflow if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "Failed to create automated PR"
-          exit 1
-

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -102,7 +102,6 @@ jobs:
       - name: Call upgrade provider action
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
-        continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@e247104aede3eb4641f48c8ad0ea9de9346f2457 # v0.0.18
         with:
           kind: provider
@@ -113,18 +112,3 @@ jobs:
           allow-missing-docs: true
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Comment on upgrade issue if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
-          gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Fail workflow if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "Failed to create automated PR"
-          exit 1
-

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Call upgrade provider action
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
-        continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@e247104aede3eb4641f48c8ad0ea9de9346f2457 # v0.0.18
         with:
           kind: provider
@@ -118,18 +117,3 @@ jobs:
           allow-missing-docs: true
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Comment on upgrade issue if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
-          gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Fail workflow if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "Failed to create automated PR"
-          exit 1
-

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
@@ -97,7 +97,6 @@ jobs:
       - name: Call upgrade provider action
         id: upgrade_provider
         if: steps.target_version.outputs.version != ''
-        continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@e247104aede3eb4641f48c8ad0ea9de9346f2457 # v0.0.18
         with:
           kind: provider
@@ -108,18 +107,3 @@ jobs:
           allow-missing-docs: true
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Comment on upgrade issue if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
-          gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_TOKEN || steps.esc-secrets.outputs.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Fail workflow if automated PR failed
-        if: steps.upgrade_provider.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "Failed to create automated PR"
-          exit 1
-


### PR DESCRIPTION
We have a visibility gap right now around upgrade-provider failures. These failures get flagged in issues like [this one](https://github.com/pulumi/pulumi-azure/issues/3367), but not in a way that surfaces them to our dashboards. For example I can't tell right now if this workflow is broken for _all_ providers or just azure.

This change causes the upgrade-provider workflow to fail if we weren't able to create a PR. This will get the failure picked up by the same automation we use for all our other workflow failures: an issue will be created and visible on our dashboards, and the issue will auto-resolve when the problem is fixed.