### PR TITLE
[update single provider] Clarify that the prefix is `pulumi-`

### DIFF
--- a/.github/workflows/update-bridge-single-ecosystem-provider.yml
+++ b/.github/workflows/update-bridge-single-ecosystem-provider.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
         default: false
       provider:
-        description: The name of the provider to update - do not include the pulumi prefix in the name.
+        description: The name of the provider to update - do not include the "pulumi-" prefix in the name.
         required: true
         type: string
 


### PR DESCRIPTION
<img width="404" height="348" alt="image" src="https://github.com/user-attachments/assets/c835e5d3-28f4-48e3-ba58-f8de3d2c2dfa" />




When I read that dialog for the first time, I understood the pulumi prefix was `pulumi/` not `pulumi-`.