### PR TITLE
Use forked version of stale-issue-cleanup

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 


### PR DESCRIPTION
Temporarily adopt forked branch https://github.com/pose/pulumi-scaleway/tree/pose/chores/updated-to-latest-and-greatest-ci-mgmt until issue is fixed upstream.

Part of #1944 