### PR TITLE
Fix upgrade-provider auth error

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -52,8 +52,7 @@ jobs:
           #{{- if .Config.CheckoutSubmodules }}#
           submodules: #{{ .Config.CheckoutSubmodules }}#
           #{{- end }}#
-          # Persist credentials so upgrade-provider can push a new branch.
-          persist-credentials: true
+          persist-credentials: false # Conflicts with app auth token.
       #{{- .Config | renderEscStep | indent 6 }}#
 #{{- if .Config.GitHubApp.Enabled }}#
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -44,8 +44,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Persist credentials so upgrade-provider can push a new branch.
-          persist-credentials: true      
+          persist-credentials: false # Conflicts with app auth token.      
       - id: esc-secrets
         name: Map environment to ESC outputs
         uses: ./.github/actions/esc-action

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -53,8 +53,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           submodules: true
-          # Persist credentials so upgrade-provider can push a new branch.
-          persist-credentials: true      
+          persist-credentials: false # Conflicts with app auth token.      
       - env:
           ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -50,8 +50,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Persist credentials so upgrade-provider can push a new branch.
-          persist-credentials: true      
+          persist-credentials: false # Conflicts with app auth token.      
       - env:
           ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -55,8 +55,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Persist credentials so upgrade-provider can push a new branch.
-          persist-credentials: true      
+          persist-credentials: false # Conflicts with app auth token.      
       - env:
           ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
@@ -45,8 +45,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          # Persist credentials so upgrade-provider can push a new branch.
-          persist-credentials: true      
+          persist-credentials: false # Conflicts with app auth token.      
       - env:
           ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
           ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"


### PR DESCRIPTION
The credentials GitHub was caching on checkout were colliding with the app auth token we're now using.

Tested and confirmed working in nomad here:
https://github.com/pulumi/pulumi-nomad/actions/runs/20377514940/job/58559746196

Fixes https://github.com/pulumi/ci-mgmt/issues/1946.