### PR TITLE
mise: retry HTTP failures more aggressively and pin by default

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/acme/.config/mise.toml
+++ b/provider-ci/test-providers/acme/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -28,6 +28,7 @@ golangci-lint = "1.64.8" # See note about about overrides if you need to customi
 experimental = true # Required for Go binaries (e.g. pulumictl).
 lockfile = false
 http_retries = 3
+pin = true # `mise use` should pin versions instead of defaulting to latest.
 
 [plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"


### PR DESCRIPTION
We occasionally see transient errors when trying to fetch artifacts. This should help reduce those failures somewhat.