### PR TITLE
Renovate pin pose/stale-issue-cleanup

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,5 +36,13 @@
       matchPackageNames: ["golangci/golangci-lint-action"],
       allowedVersions: "^6",
     },
+    {
+      // Until we get our change merged upstream, Renovate should track
+      // pose/fixes/correct-transpilation-arguments branch instead of main.
+      // See: https://github.com/aws-actions/stale-issue-cleanup/issues/385
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["pose/stale-issue-cleanup"],
+      enabled: false
+    }
   ],
 }


### PR DESCRIPTION
Fixes #1954 
Part of #1944 

Required since renovate wanted to use the `main` branch of the `stale-issue-cleanup` fork instead of the fix branch.