### PR TITLE
Rollback renovate commit

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Stale issue job
     steps:
     # Workaround until https://github.com/aws-actions/stale-issue-cleanup/issues/385 is fixed
-    - uses: pose/stale-issue-cleanup@db44981197ae9cdada9a9c779c052439f9d62eac
+    - uses: pose/stale-issue-cleanup@04621e0eafc22d7bb8812c417325f35cc0ed0fce
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 


### PR DESCRIPTION
Fixes #1954 

I thought I rolled back this change as the previous PR: https://github.com/pulumi/ci-mgmt/pull/1955 but it seems I somehow missed it.

This reverts commit 1901fce160a37d0c537d831ce6f96e72bf7c9427.