### PR TITLE
Add explicit permissions to workflow templates

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/community-moderation.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: #{{ .Config.Runner.Default }}#
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.ActionVersions.Checkout }}#

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/release_command.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.ActionVersions.Checkout }}#

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/pull-request.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/aws-native/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/aws-native/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/aws-native/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/aws/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: pulumi-ubuntu-8core
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/command/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/command/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/command/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/command/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/command/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/docker-build/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/docker-build/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/docker-build/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/docker/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/eks/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/eks/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
       with:

--- a/provider-ci/test-providers/xyz/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/community-moderation.yml
@@ -4,6 +4,8 @@ jobs:
   warn_codegen:
     name: warn_codegen
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/provider-ci/test-providers/xyz/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/release_command.yml
@@ -9,6 +9,10 @@ jobs:
   should_release:
     name: Should release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Summary
- Add explicit `permissions:` blocks to workflow templates that use `secrets.GITHUB_TOKEN` for write operations

## Background
GitHub's default `GITHUB_TOKEN` permissions are now read-only for `contents` and `packages` scopes. Workflows that need write access (commenting on PRs/issues, managing labels) must explicitly declare permissions.

## Changes

| Template | Permissions Added |
|----------|-------------------|
| `release_command.yml` | `contents: read`, `pull-requests: write`, `id-token: write` |
| `comment-on-stale-issues.yml` | `issues: write` |
| `community-moderation.yml` | `pull-requests: write` |
| `native/pull-request.yml` | `pull-requests: write` |

## Testing
- Ran `make clean && make -j` in `provider-ci/` directory
- Build completed successfully
- Generated test providers include the new permissions blocks