### PR TITLE
Allow native Prerequisites job to have configurable runners

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   prerequisites:
-    runs-on: ubuntu-latest
+    runs-on: #{{ if .Config.Runner.Prerequisites }}##{{ .Config.Runner.Prerequisites }}##{{ else }}#ubuntu-latest#{{ end }}#
     name: prerequisites
     #{{- if eq .Config.Provider "aws-native" }}#
     permissions:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   prerequisites:
-    runs-on: ubuntu-latest
+    runs-on: #{{ if .Config.Runner.Prerequisites }}##{{ .Config.Runner.Prerequisites }}##{{ else }}#ubuntu-latest#{{ end }}#
     name: prerequisites
     permissions:
       id-token: write # For ESC secrets.

--- a/provider-ci/test-providers/kubernetes/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/kubernetes/.ci-mgmt.yaml
@@ -19,3 +19,4 @@ envOverride:
     GOOGLE_PROJECT_NUMBER: 637339343727
 runner:
     publish: pulumi-ubuntu-8core
+    prerequisites: pulumi-ubuntu-8core

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   prerequisites:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     name: prerequisites
     steps:
     - name: Checkout Repo

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   prerequisites:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     name: prerequisites
     permissions:
       id-token: write # For ESC secrets.


### PR DESCRIPTION
We have a `runners` config key that is meant to allow a provider maintainer to adjust the runner size for a few select jobs, but the native provider templates did not allow for this. This pull request adds configurability to the `prerequisites` job in the run-acceptance-tests, release and prerelease workflows.

This is a hotfix prerequisite for https://github.com/pulumi/pulumi-kubernetes/issues/4052 and https://github.com/pulumi/pulumi-kubernetes/issues/4076 and does not purport to be complete, or a thorough refactor for native provider workflows.

- **Ensure that prereleases also can adjust their runner size**
- **Allow for prerequisites job to also have configurable runners**
