### PR TITLE
Set GITHUB_TOKEN for fetching schema

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -118,6 +118,8 @@ jobs:
 #{{- if not .Config.NoSchema }}#
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -99,6 +99,8 @@ jobs:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -115,6 +115,8 @@ jobs:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -116,6 +116,8 @@ jobs:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -122,6 +122,8 @@ jobs:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -130,6 +130,8 @@ jobs:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -106,6 +106,8 @@ jobs:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: inputs.is_pr
       name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {


### PR DESCRIPTION
Saw this error recently

```
ERROR: logging before flag.Parse: E0114 10:45:19.011327    7388 log.go:80] GitHub rate limit exceeded for https://api.github.com/repos/pulumi/pulumi-aws-apigateway/contents/provider/cmd/pulumi-resource-aws-apigateway/schema.json?ref=main, try again in 37m16.988702071s. You can set GITHUB_TOKEN to make an authenticated request with a higher rate limit.
Error: rate limit exceeded: 403 HTTP error fetching schema from https://api.github.com/repos/pulumi/pulumi-aws-apigateway/contents/provider/cmd/pulumi-resource-aws-apigateway/schema.json?ref=main

```