### PR TITLE
s/BuildSdk/BuildSDK/

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: #{{ if .Config.Runner.BuildSDK }}##{{- .Config.Runner.BuildSdk }}##{{ else }}##{{- .Config.Runner.Default }}##{{ end }}#
+    runs-on: #{{ if .Config.Runner.BuildSDK }}##{{- .Config.Runner.BuildSDK }}##{{ else }}##{{- .Config.Runner.Default }}##{{ end }}#
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
     steps:


### PR DESCRIPTION
Fix a typo in the test.yml template. The proper reference is `BuildSDK`.
