### PR TITLE
Don't ignore sdk/go/**/schema.go

### DIFF
--- a/provider-ci/internal/pkg/migrations/migrations.go
+++ b/provider-ci/internal/pkg/migrations/migrations.go
@@ -25,6 +25,7 @@ func Migrate(templateName, outDir string) error {
 		migrateCimgmtOverrides{},
 		maintainMiseLock{},
 		maintainGolangciConfig{},
+		unignoreSDKSchemaGo{},
 	}
 	for i, migration := range migrations {
 		if !migration.ShouldRun(templateName) {

--- a/provider-ci/internal/pkg/migrations/unignore_sdk_schema.go
+++ b/provider-ci/internal/pkg/migrations/unignore_sdk_schema.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// schema.go should not be ignored if it's part of the Go SDK.
+type unignoreSDKSchemaGo struct{}
+
+func (unignoreSDKSchemaGo) Name() string {
+	return "Exclude sdk/go/**/schema.go from .gitignore"
+}
+func (unignoreSDKSchemaGo) ShouldRun(templateName string) bool {
+	return templateName == "bridged-provider" || templateName == "all"
+}
+func (unignoreSDKSchemaGo) Migrate(templateName, outDir string) error {
+	gitignorePath := filepath.Join(outDir, ".gitignore")
+	gitignore, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error reading .gitignore: %w", err)
+		}
+		gitignore = []byte{}
+	}
+	gitignoreString := string(gitignore)
+	if !strings.Contains(gitignoreString, "sdk/go/**/schema.go") {
+		gitignoreString += "\n# Don't ignore schema.go if it's part of the Go SDK\n!sdk/go/**/schema.go\n"
+		err := os.WriteFile(gitignorePath, []byte(gitignoreString), 0644)
+		if err != nil {
+			return fmt.Errorf("error writing to .gitignore: %w", err)
+		}
+		return err
+	}
+	return nil
+}

--- a/provider-ci/test-providers/aws/.gitignore
+++ b/provider-ci/test-providers/aws/.gitignore
@@ -6,3 +6,6 @@
 
 # Ignore local mise config
 mise.local.toml
+
+# Don't ignore schema.go if it's part of the Go SDK
+!sdk/go/**/schema.go

--- a/provider-ci/test-providers/cloudflare/.gitignore
+++ b/provider-ci/test-providers/cloudflare/.gitignore
@@ -6,3 +6,6 @@
 
 # Ignore local mise config
 mise.local.toml
+
+# Don't ignore schema.go if it's part of the Go SDK
+!sdk/go/**/schema.go

--- a/provider-ci/test-providers/docker/.gitignore
+++ b/provider-ci/test-providers/docker/.gitignore
@@ -6,3 +6,6 @@
 
 # Ignore local mise config
 mise.local.toml
+
+# Don't ignore schema.go if it's part of the Go SDK
+!sdk/go/**/schema.go

--- a/provider-ci/test-providers/xyz/.gitignore
+++ b/provider-ci/test-providers/xyz/.gitignore
@@ -6,3 +6,6 @@
 
 # Ignore local mise config
 mise.local.toml
+
+# Don't ignore schema.go if it's part of the Go SDK
+!sdk/go/**/schema.go


### PR DESCRIPTION
These changes add a migration that unignores sdk/go/**/schema.go. These
files are proper parts of our Go SDKs, as they represent resources named
(you guessed it) Schema.

Will fix https://github.com/pulumi/pulumi-gcp/issues/3522 once it's
rolled out.
