### PR TITLE
Better stack traces for 'comment on stale issues'

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/command/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/comment-on-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440
+    - uses: pose/stale-issue-cleanup@6c41dce28d1467899a804a8e4107d4d8b44f71f9
       with:
         issue-types: issues # only look at issues (ignore pull-requests)
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,5 +36,13 @@
       matchPackageNames: ["golangci/golangci-lint-action"],
       allowedVersions: "^6",
     },
+    {
+      // Until we get our change merged upstream, Renovate should track
+      // pose/chores/better-stack-traces branch instead of main.
+      // See: https://github.com/pulumi/ci-mgmt/issues/1987
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["pose/chores/better-stack-traces"],
+      enabled: false
+    }
   ],
 }


### PR DESCRIPTION
Part of #1987

Unfortunately, we are still getting some intermittent issues from time to time with 'comment on stale issues' workflow and I'm unable to reproduce them. The printed error doesn't have a meaningful stack trace and I can only see that it exits with exit code 1. Example: https://github.com/pulumi/pulumi-kubernetes/actions/runs/21197820169/job/60977392333#step:2:730

I forked again the `stale-issue-cleanup` repo and I changed the transpilation to include the sourcemaps. While we wait for upstream to incorporate the change, I am pointing the action to my fork: https://github.com/pose/stale-issue-cleanup/tree/pose/chores/better-stack-traces to see if we can diagnose the problem.

