### PR TITLE
mise: Use explicit github backend for pulumi

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/acme/.config/mise.toml
+++ b/provider-ci/test-providers/acme/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -17,7 +17,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-pulumi = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'


### PR DESCRIPTION
I've been seeing newer versions of mise (seemingly randomly) complain about not being able to find pulumi in the tool registry.

```
❯ mise install
mise ERROR pulumi not found in mise tool registry
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

This switches us to an explicit GitHub backend similar to how we're already installing pulumictl and schema-tools.