### PR TITLE
Remove custom p-kubernetes tool setup

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -398,26 +398,6 @@ jobs:
       with:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
-    #{{- end }}#
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -687,15 +667,6 @@ jobs:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Set stack name in output
@@ -757,15 +728,6 @@ jobs:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Generate Pulumi access token for k8s infra

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -358,26 +358,6 @@ jobs:
       with:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
-    #{{- end }}#
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -711,15 +691,6 @@ jobs:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Set stack name in output
@@ -781,15 +752,6 @@ jobs:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Generate Pulumi access token for k8s infra

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -360,26 +360,6 @@ jobs:
       with:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
-    #{{- end }}#
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -745,15 +725,6 @@ jobs:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Set stack name in output
@@ -815,15 +786,6 @@ jobs:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Generate Pulumi access token for k8s infra

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -495,26 +495,6 @@ jobs:
       with:
         install_components: gke-gcloud-auth-plugin
     #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    #{{- end }}#
-    #{{- if eq .Config.Provider "kubernetes" }}#
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
-    #{{- end }}#
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -369,22 +369,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -628,15 +612,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Set stack name in output
@@ -692,15 +667,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Generate Pulumi access token for k8s infra

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -325,22 +325,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -652,15 +636,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Set stack name in output
@@ -716,15 +691,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Generate Pulumi access token for k8s infra

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -325,22 +325,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:
@@ -688,15 +672,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Set stack name in output
@@ -752,15 +727,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker gcr.io,us-central1-docker.pkg.dev # Ensure that all test artifact registry locations are supplied here.
     - name: Generate Pulumi access token for k8s infra

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -468,22 +468,6 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         install_components: gke-gcloud-auth-plugin
-    - name: Install Kubectl
-      run: >
-        curl -LO
-        "https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl"
-
-        chmod +x ./kubectl
-
-        sudo mv kubectl /usr/local/bin
-    - name: Install and configure Helm
-      run: |
-        curl -LO  https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-        tar -xvf helm-v3.8.0-linux-amd64.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin
-        helm repo add stable https://charts.helm.sh/stable
-        helm repo update
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:


### PR DESCRIPTION
After https://github.com/pulumi/pulumi-kubernetes/pull/4103 we no longer need to install these tools via ci-mgmt.

Verifying here: https://github.com/pulumi/pulumi-kubernetes/pull/4104