### PR TITLE
Remove hardcoded name in skill

### DIFF
--- a/provider-ci/internal/pkg/templates/internal-bridged/.claude/skills/pulumi-upgrade-provider/SKILL.md
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.claude/skills/pulumi-upgrade-provider/SKILL.md
@@ -57,7 +57,7 @@ mkdir -p .pulumi
 2. Run the upgrade tool from the repo root with a 10-minute timeout:
 
 ```bash
-upgrade-provider pulumi/pulumi-digitalocean --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
 ```
 
 Use `timeout: 600000` (10 minutes) when invoking via Bash.

--- a/provider-ci/test-providers/aws/.claude/skills/pulumi-upgrade-provider/SKILL.md
+++ b/provider-ci/test-providers/aws/.claude/skills/pulumi-upgrade-provider/SKILL.md
@@ -57,7 +57,7 @@ mkdir -p .pulumi
 2. Run the upgrade tool from the repo root with a 10-minute timeout:
 
 ```bash
-upgrade-provider pulumi/pulumi-digitalocean --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
 ```
 
 Use `timeout: 600000` (10 minutes) when invoking via Bash.

--- a/provider-ci/test-providers/cloudflare/.claude/skills/pulumi-upgrade-provider/SKILL.md
+++ b/provider-ci/test-providers/cloudflare/.claude/skills/pulumi-upgrade-provider/SKILL.md
@@ -57,7 +57,7 @@ mkdir -p .pulumi
 2. Run the upgrade tool from the repo root with a 10-minute timeout:
 
 ```bash
-upgrade-provider pulumi/pulumi-digitalocean --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
 ```
 
 Use `timeout: 600000` (10 minutes) when invoking via Bash.

--- a/provider-ci/test-providers/docker/.claude/skills/pulumi-upgrade-provider/SKILL.md
+++ b/provider-ci/test-providers/docker/.claude/skills/pulumi-upgrade-provider/SKILL.md
@@ -57,7 +57,7 @@ mkdir -p .pulumi
 2. Run the upgrade tool from the repo root with a 10-minute timeout:
 
 ```bash
-upgrade-provider pulumi/pulumi-digitalocean --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
 ```
 
 Use `timeout: 600000` (10 minutes) when invoking via Bash.

--- a/provider-ci/test-providers/xyz/.claude/skills/pulumi-upgrade-provider/SKILL.md
+++ b/provider-ci/test-providers/xyz/.claude/skills/pulumi-upgrade-provider/SKILL.md
@@ -57,7 +57,7 @@ mkdir -p .pulumi
 2. Run the upgrade tool from the repo root with a 10-minute timeout:
 
 ```bash
-upgrade-provider pulumi/pulumi-digitalocean --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
+upgrade-provider $ORG/$REPO --repo-path . > .pulumi/upgrade-provider-stdout.txt 2> /dev/null
 ```
 
 Use `timeout: 600000` (10 minutes) when invoking via Bash.


### PR DESCRIPTION
Copied over changes from testing in digitalocean. Revert to generic instructions