### PR TITLE
Customizable targets

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/defaults.mk
+++ b/provider-ci/internal/pkg/templates/all/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -50,6 +50,8 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=#{{- range .Config.ExtraLDFlags }}# #{{ . }}# #{{- end }}#
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -262,17 +264,23 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-lint_provider: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-# `lint_provider.fix` is a utility target meant to be run manually
+.PHONY: lint
+lint: upstream lint.pre default.lint lint.post
+
+# `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix: upstream
+.PHONY: lint.fix
+lint.fix: upstream lint.pre default.lint.fix lint.post
+
+.PHONY: lint.pre
+lint.pre:
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+
+.PHONY: lint.post
+lint.post:
 	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-.PHONY: lint_provider lint_provider.fix
+
+.PHONY: lint lint.fix
 
 #{{- if .Config.BuildProviderCmd }}#
 build_provider_cmd = #{{ if .Config.BuildProviderPre -}}#

--- a/provider-ci/internal/pkg/templates/parameterized-go/Makefile
+++ b/provider-ci/internal/pkg/templates/parameterized-go/Makefile
@@ -32,6 +32,8 @@ LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(GO_MODULE)/pkg/version.Version=$(PROVIDER_VERSION)#{{if .Config.ProviderVersion}}# -X #{{ .Config.ProviderVersion }}#=$(PROVIDER_VERSION)#{{end}}#
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -96,15 +98,15 @@ clean:
 	rm -rf .make/*
 .PHONY: clean
 
-lint_provider: provider
+.PHONY: lint
+lint: provider
 	golangci-lint run -c .golangci.yml
 
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix:
+.PHONY: lint.fix
+lint.fix:
 	golangci-lint run -c .golangci.yml --fix
-
-.PHONY: lint_provider lint_provider.fix
 
 #{{- if .Config.BuildProviderCmd }}#
 build_provider_cmd = #{{ if .Config.BuildProviderPre -}}#

--- a/provider-ci/test-providers/aws-native/.config/defaults.mk
+++ b/provider-ci/test-providers/aws-native/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/aws/.config/defaults.mk
+++ b/provider-ci/test-providers/aws/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -30,6 +30,8 @@ LDFLAGS_UPSTREAM_VERSION=-X github.com/hashicorp/terraform-provider-aws/version.
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -214,17 +216,23 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-lint_provider: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-# `lint_provider.fix` is a utility target meant to be run manually
+.PHONY: lint
+lint: upstream lint.pre default.lint lint.post
+
+# `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix: upstream
+.PHONY: lint.fix
+lint.fix: upstream lint.pre default.lint.fix lint.post
+
+.PHONY: lint.pre
+lint.pre:
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+
+.PHONY: lint.post
+lint.post:
 	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-.PHONY: lint_provider lint_provider.fix
+
+.PHONY: lint lint.fix
 build_provider_cmd = VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh;cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/test-providers/cloudflare/.config/defaults.mk
+++ b/provider-ci/test-providers/cloudflare/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -30,6 +30,8 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -221,17 +223,23 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-lint_provider: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-# `lint_provider.fix` is a utility target meant to be run manually
+.PHONY: lint
+lint: upstream lint.pre default.lint lint.post
+
+# `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix: upstream
+.PHONY: lint.fix
+lint.fix: upstream lint.pre default.lint.fix lint.post
+
+.PHONY: lint.pre
+lint.pre:
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+
+.PHONY: lint.post
+lint.post:
 	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-.PHONY: lint_provider lint_provider.fix
+
+.PHONY: lint lint.fix
 build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/test-providers/command/.config/defaults.mk
+++ b/provider-ci/test-providers/command/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/docker-build/.config/defaults.mk
+++ b/provider-ci/test-providers/docker-build/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/docker/.config/defaults.mk
+++ b/provider-ci/test-providers/docker/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -30,6 +30,8 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -226,17 +228,23 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-lint_provider: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-# `lint_provider.fix` is a utility target meant to be run manually
+.PHONY: lint
+lint: upstream lint.pre default.lint lint.post
+
+# `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix: upstream
+.PHONY: lint.fix
+lint.fix: upstream lint.pre default.lint.fix lint.post
+
+.PHONY: lint.pre
+lint.pre:
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+
+.PHONY: lint.post
+lint.post:
 	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-.PHONY: lint_provider lint_provider.fix
+
+.PHONY: lint lint.fix
 build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/test-providers/eks/.config/defaults.mk
+++ b/provider-ci/test-providers/eks/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -30,6 +30,8 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -215,17 +217,23 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-lint_provider: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-# `lint_provider.fix` is a utility target meant to be run manually
+.PHONY: lint
+lint: upstream lint.pre default.lint lint.post
+
+# `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix: upstream
+.PHONY: lint.fix
+lint.fix: upstream lint.pre default.lint.fix lint.post
+
+.PHONY: lint.pre
+lint.pre:
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+
+.PHONY: lint.post
+lint.post:
 	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-.PHONY: lint_provider lint_provider.fix
+
+.PHONY: lint lint.fix
 build_provider_cmd = OS=$(1) ARCH=$(2) OUT=$(3) yarn --cwd nodejs/eks build
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/defaults.mk
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/kubernetes-coredns/.config/defaults.mk
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/defaults.mk
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/kubernetes/.config/defaults.mk
+++ b/provider-ci/test-providers/kubernetes/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/defaults.mk
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/terraform-module/.config/defaults.mk
+++ b/provider-ci/test-providers/terraform-module/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/terraform-module/Makefile
+++ b/provider-ci/test-providers/terraform-module/Makefile
@@ -24,6 +24,8 @@ LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(GO_MODULE)/pkg/version.Version=$(PROVIDER_VERSION)
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -88,15 +90,15 @@ clean:
 	rm -rf .make/*
 .PHONY: clean
 
-lint_provider: provider
+.PHONY: lint
+lint: provider
 	golangci-lint run -c .golangci.yml
 
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix:
+.PHONY: lint.fix
+lint.fix:
 	golangci-lint run -c .golangci.yml --fix
-
-.PHONY: lint_provider lint_provider.fix
 build_provider_cmd = GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(GO_MODULE)/cmd/$(PROVIDER)
 
 .PHONY: provider

--- a/provider-ci/test-providers/xyz/.config/defaults.mk
+++ b/provider-ci/test-providers/xyz/.config/defaults.mk
@@ -1,0 +1,41 @@
+# This file contains default make targets used by provders. To use it,
+# add this to the top of your Makefile:
+#
+#     include .config/defaults.mk
+#
+# This will expose default targets that should "just work" without any
+# customization.
+#
+# To extend or customize the default behavior, you can:
+#
+#    1. Override targets:
+#
+#           lint:
+#              ./custom-lint.sh
+#
+#    2. Compose targets:
+#
+#           lint: lint.pre default.lint lint.post
+#
+#       (Remember make processes dependencies from left to right.)
+#
+# Default targets contain our actual implementations and are prefixed with
+# "default." in order to enable wrapping. They are not meant to be overridden.
+
+# TODO(https://github.com/pulumi/ci-mgmt/issues/2033): This should lint the
+# entire repo, not just the provider subdirectory.
+.PHONY: default.lint
+default.lint:
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
+
+.PHONY: default.lint.fix
+default.lint.fix:
+	cd provider && golangci-lint run --fix --path-prefix provider -c ../.golangci.yml
+
+# The public targets below are actually consumed by CI.
+
+.PHONY: lint
+lint: default.lint
+
+.PHONY: lint.fix
+lint.fix: default.lint.fix

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -30,6 +30,8 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+include .config/defaults.mk
+
 # Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
 # For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
 # file within `.make/` to track the staleness of the target and only rebuild when needed.
@@ -214,17 +216,23 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-lint_provider: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-# `lint_provider.fix` is a utility target meant to be run manually
+.PHONY: lint
+lint: upstream lint.pre default.lint lint.post
+
+# `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
-lint_provider.fix: upstream
+.PHONY: lint.fix
+lint.fix: upstream lint.pre default.lint.fix lint.post
+
+.PHONY: lint.pre
+lint.pre:
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+
+.PHONY: lint.post
+lint.post:
 	git grep -l 'goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'
-.PHONY: lint_provider lint_provider.fix
+
+.PHONY: lint lint.fix
 build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)


### PR DESCRIPTION
This lays groundwork for https://github.com/pulumi/ci-mgmt/issues/1131 by shipping some default targets (currently just lint) and including those in Makefiles.

The list of targets in defaults.mk will essentially become our CI/provider contract. That is, as we start extracting default behaviors we should also be updating CI to invoke those targets directly for local & CI to share overridden behaviors.

Related to https://github.com/pulumi/ci-mgmt/pull/2024.