### PR TITLE
Update to mise version 2026.2.10

### DIFF
--- a/.github/workflows/test-provider-ci.yml
+++ b/.github/workflows/test-provider-ci.yml
@@ -30,10 +30,9 @@ jobs:
         # The branch doesn't matter here because it's only used for a temp repo for actionlint
         run: git config --global init.defaultBranch master
       - name: Install mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
-          plugin_install: https://github.com/pulumi/vfox-pulumi
+          version: 2026.2.10
       - name: Build & test
         run: cd provider-ci && make all
       - name: Check worktree clean

--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -67,10 +67,9 @@ jobs:
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/pull_request.yml || echo "not found"
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/master.yml || echo "not found"
       - name: Install mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
-          plugin_install: https://github.com/pulumi/vfox-pulumi
+          version: 2026.2.10
           install_args: go golangci-lint
           cache_key_prefix: mise-v0-${{ inputs.provider_name}}-
           working_directory: pulumi-${{ inputs.provider_name }}

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -336,6 +336,9 @@ type Config struct {
 
 	// UseJavaPackageGenSdk controls whether we use the Java SDK generation via package gen-sdk
 	UseJavaPackageGenSdk bool `yaml:"useJavaPackageGenSdk"`
+
+	// MiseVersion specifies the version of mise to use on GitHub Actions.
+	MiseVersion string `yaml:"mise-version"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/templates/all/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/all/.github/workflows/lint.yml
@@ -44,13 +44,12 @@ jobs:
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -70,13 +70,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -61,13 +61,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/license.yml
@@ -32,13 +32,12 @@ jobs:
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -72,13 +72,12 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     #{{- end }}#
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -54,13 +54,12 @@ jobs:
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
 #{{- if .Config.Publish.CDN }}#
     - name: Configure AWS Credentials
@@ -161,13 +160,12 @@ jobs:
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -60,14 +60,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -75,12 +75,11 @@ jobs:
           persist-credentials: false
       #{{- .Config | renderEscStep | indent 6 }}#
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-bridge.yml
@@ -95,13 +95,12 @@ jobs:
         owner: ${{ github.repository_owner }}
 #{{- end }}#
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Call upgrade provider action

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -63,13 +63,12 @@ jobs:
           owner: ${{ github.repository_owner }}
 #{{- end }}#
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Install upgrade-provider

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -235,3 +235,6 @@ github-app:
 
 # Enables Java SDK generation via package gen-sdk
 useJavaPackageGenSdk: false
+
+# Version of mise to use
+mise-version: 2026.2.10

--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
@@ -49,13 +49,12 @@ jobs:
           aws-region: us-west-2
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/claude.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: #{{ .Config.MiseVersion }}#
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: #{{ .Config.MiseVersion }}#
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/aws-native/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/aws-native/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/lint.yml
@@ -41,13 +41,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -72,13 +72,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -72,13 +72,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/aws/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -44,13 +44,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -52,13 +52,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
@@ -59,13 +59,12 @@ jobs:
           aws-region: us-west-2
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -78,13 +78,12 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -63,13 +63,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
@@ -161,13 +160,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -65,14 +65,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -103,13 +103,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Call upgrade provider action

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -70,13 +70,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Install upgrade-provider

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -71,12 +71,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -71,13 +71,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -69,13 +69,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/cloudflare/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -42,13 +42,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -49,13 +49,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/cloudflare/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/main-post-build.yml
@@ -56,13 +56,12 @@ jobs:
           aws-region: us-west-2
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -75,13 +75,12 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -60,13 +60,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
@@ -157,13 +156,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
@@ -63,14 +63,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -100,13 +100,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Call upgrade provider action

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -67,13 +67,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Install upgrade-provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -75,12 +75,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/command/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/command/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/command/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/command/.github/workflows/lint.yml
@@ -40,13 +40,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/docker-build/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/docker-build/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/lint.yml
@@ -51,13 +51,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -63,13 +63,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -74,13 +74,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/docker/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -54,13 +54,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -54,13 +54,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/docker/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/main-post-build.yml
@@ -68,13 +68,12 @@ jobs:
           aws-region: us-west-2
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -80,13 +80,12 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -72,13 +72,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
@@ -169,13 +168,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/test-providers/docker/.github/workflows/test.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/test.yml
@@ -68,14 +68,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -105,13 +105,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Call upgrade provider action

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -72,13 +72,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Install upgrade-provider

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -87,12 +87,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -63,13 +63,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -71,13 +71,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/eks/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/eks/.github/workflows/license.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/license.yml
@@ -51,13 +51,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/eks/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/lint.yml
@@ -51,13 +51,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -77,13 +77,12 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -69,13 +69,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
@@ -166,13 +165,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/test-providers/eks/.github/workflows/test.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/test.yml
@@ -64,14 +64,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -78,12 +78,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/lint.yml
@@ -45,13 +45,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/lint.yml
@@ -45,13 +45,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/lint.yml
@@ -45,13 +45,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/kubernetes/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/kubernetes/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/lint.yml
@@ -46,13 +46,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
@@ -14,14 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
 
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/lint.yml
@@ -39,13 +39,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_provider.yml
@@ -63,13 +63,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
@@ -67,13 +67,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/license.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/license.yml
@@ -47,13 +47,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/lint.yml
@@ -47,13 +47,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -73,13 +73,12 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/publish.yml
@@ -65,13 +65,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
@@ -162,13 +161,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/test.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/test.yml
@@ -60,14 +60,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/verify-release.yml
@@ -80,12 +80,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -63,13 +63,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/terraform-module/.github/workflows/license.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/license.yml
@@ -43,13 +43,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/terraform-module/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/lint.yml
@@ -43,13 +43,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -63,13 +63,12 @@ jobs:
         major-version: 0
         set-env: 'PROVIDER_VERSION'
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/terraform-module/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/publish.yml
@@ -61,13 +61,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1

--- a/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/test.yml
@@ -56,14 +56,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/terraform-module/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/verify-release.yml
@@ -76,12 +76,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/provider-ci/test-providers/xyz/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_provider.yml
@@ -63,13 +63,12 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -64,13 +64,12 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/xyz/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/claude.yml
@@ -56,13 +56,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Prepare local workspace

--- a/provider-ci/test-providers/xyz/.github/workflows/license.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/license.yml
@@ -44,13 +44,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - run: make prepare_local_workspace

--- a/provider-ci/test-providers/xyz/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/lint.yml
@@ -44,13 +44,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false # A different job handles caching our tools.
     - name: prepare workspace
       continue-on-error: true

--- a/provider-ci/test-providers/xyz/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/main-post-build.yml
@@ -58,13 +58,12 @@ jobs:
           aws-region: us-west-2
           aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Setup Go Cache

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -70,13 +70,12 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache

--- a/provider-ci/test-providers/xyz/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/publish.yml
@@ -62,13 +62,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         cache_save: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
@@ -159,13 +158,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node

--- a/provider-ci/test-providers/xyz/.github/workflows/test.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/test.yml
@@ -58,14 +58,13 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # also save this cache since we are using a different mise env.
         cache_save: true
     - name: Prepare local workspace

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-bridge.yml
@@ -95,13 +95,12 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: blampe/mise-action@blampe/plugins
+      uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2026.1.1
+        version: 2026.2.10
         github_token: ${{ steps.app-auth.outputs.token }}
-        plugin_install: https://github.com/pulumi/vfox-pulumi
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Call upgrade provider action

--- a/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/upgrade-provider.yml
@@ -62,13 +62,12 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ steps.app-auth.outputs.token }}
-          plugin_install: https://github.com/pulumi/vfox-pulumi
           # only saving the cache in the prerequisites job
           cache_save: false
       - name: Install upgrade-provider

--- a/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
@@ -71,12 +71,11 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: blampe/mise-action@blampe/plugins
+        uses: jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310
         with:
-          version: 2026.1.1
+          version: 2026.2.10
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-          plugin_install: https://github.com/pulumi/vfox-pulumi
       - name: Setup Go Cache
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:


### PR DESCRIPTION
Fixes #2038
Depends on https://github.com/jdx/mise/pull/8082

This change also introduces a `.ci-mgmt.yaml` overridable property called `mise-version` (referred in the templates as `MiseVersion` to determine which version of `mise` to use on `mise` GitHub Actions.