### PR TITLE
Remove `get_env` from Pulumi and Go version setting

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/pulumiservice/.config/mise.toml
+++ b/provider-ci/test-providers/pulumiservice/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/pulumiservice/go.mod
+++ b/provider-ci/test-providers/pulumiservice/go.mod
@@ -4,3 +4,6 @@ go 1.24.7
 
 toolchain go1.24.9
 
+require (
+	github.com/pulumi/pulumi/pkg/v3 v2.220.0
+)

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -8,8 +8,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 [tools]
 
 # Runtimes
-# TODO: we may not need 'get_env' once https://github.com/jdx/mise/discussions/6339 is fixed
-go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
+go = "{{ env.GO_VERSION_MISE }}"
 node = '20.19.5'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
@@ -17,7 +16,7 @@ python = '3.11.8'
 java = 'corretto-11'
 
 # Executable tools
-"github:pulumi/pulumi" = "{{ get_env(name='PULUMI_VERSION_MISE', default='latest') }}"
+"github:pulumi/pulumi" = "{{ env.PULUMI_VERSION_MISE }}"
 "github:pulumi/pulumictl" = '0.0.50'
 "github:pulumi/schema-tools" = "0.6.0"
 "aqua:gradle/gradle-distributions" = '7.6.6'


### PR DESCRIPTION
This is no longer required as https://github.com/jdx/mise/discussions/6339 has been resolved by https://github.com/jdx/mise/pull/7895 (thanks again @corymhall). We can now consume `env` variables directly.

Given the huge blast radius of this change, I am triggering a dry-run on all providers first: https://github.com/pulumi/ci-mgmt/actions/runs/21947234269

From that run the only workflows that failed were:
* https://github.com/pulumi/pulumi-gcp/pull/3583
* https://github.com/pulumi/pulumi-vault/pull/954
* https://github.com/pulumi/pulumi-terraform-module/pull/727
* https://github.com/pulumi/pulumi-kubernetes/pull/4141

And I verified those errors are unrelated to the change itself.