### PR TITLE
Add package gen-sdk toggle for Java SDK

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -333,6 +333,9 @@ type Config struct {
 
 	// GitHubApp contains our GitHub app auth parameters. Enabled by default.
 	GitHubApp GitHubApp `yaml:"github-app"`
+
+	// UseJavaPackageGenSdk controls whether we use the Java SDK generation via package gen-sdk
+	UseJavaPackageGenSdk bool `yaml:"useJavaPackageGenSdk"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -159,7 +159,7 @@ build_go: .make/build_go
 
 generate_java: .make/generate_java
 build_java: .make/build_java
-#{{- if or (eq .Config.Provider "eks") (eq .Config.Provider "awsx") (eq .Config.Provider "aws-apigateway") }}#
+#{{- if .Config.UseJavaPackageGenSdk }}#
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/generate_java: PACKAGE_VERSION := $(PROVIDER_VERSION)
 .make/generate_java: .make/mise_install .make/schema

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -232,3 +232,6 @@ github-app:
   enabled: true
   id: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
   private-key: ${{ secrets.PULUMI_PROVIDER_AUTOMATION_SECRET_KEY }}
+
+# Enables Java SDK generation via package gen-sdk
+useJavaPackageGenSdk: false

--- a/provider-ci/test-providers/eks/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/eks/.ci-mgmt.yaml
@@ -60,3 +60,5 @@ actions:
 releaseVerification:
   nodejs: examples/cluster
   dotnet: examples/cluster-cs
+
+useJavaPackageGenSdk: true


### PR DESCRIPTION
Part of #2011

**IMPORTANT**: Do not merge before:
* https://github.com/pulumi/pulumi-awsx/pull/1859
* https://github.com/pulumi/pulumi-eks/pull/2103
* https://github.com/pulumi/pulumi-aws-apigateway/pull/619

Added `useJavaPackageGenSdk` to `.ci-mgmt.yaml` to toggle whether we use the `pulumi-<provider>-gen` binary or the `pulimi package gen-sdk` mechanism.

Workflows verified: 
* https://github.com/pulumi/ci-mgmt/actions/runs/21916884936
* https://github.com/pulumi/ci-mgmt/actions/runs/21916979802
* https://github.com/pulumi/ci-mgmt/actions/runs/21917102841