### PR TITLE
Add package gen-sdk toggles for Dotnet, Go, NodeJS, and Python SDKs

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -337,6 +337,18 @@ type Config struct {
 	// UseJavaPackageGenSdk controls whether we use the Java SDK generation via package gen-sdk
 	UseJavaPackageGenSdk bool `yaml:"useJavaPackageGenSdk"`
 
+	// UseDotnetPackageGenSdk controls whether we use the Dotnet SDK generation via package gen-sdk
+	UseDotnetPackageGenSdk bool `yaml:"useDotnetPackageGenSdk"`
+
+	// UseGoPackageGenSdk controls whether we use the Go SDK generation via package gen-sdk
+	UseGoPackageGenSdk bool `yaml:"useGoPackageGenSdk"`
+
+	// UseNodejsPackageGenSdk controls whether we use the NodeJS SDK generation via package gen-sdk
+	UseNodejsPackageGenSdk bool `yaml:"useNodejsPackageGenSdk"`
+
+	// UsePythonPackageGenSdk controls whether we use the Python SDK generation via package gen-sdk
+	UsePythonPackageGenSdk bool `yaml:"usePythonPackageGenSdk"`
+
 	// MiseVersion specifies the version of mise to use on GitHub Actions.
 	MiseVersion string `yaml:"mise-version"`
 }

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -134,6 +134,13 @@ GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(G
 
 generate_dotnet: .make/generate_dotnet
 build_dotnet: .make/build_dotnet
+#{{- if .Config.UseDotnetPackageGenSdk }}#
+.make/generate_dotnet: .make/mise_install#{{- if not .Config.NoSchema }}# .make/schema#{{- end }}#
+.make/generate_dotnet: | mise_env
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --version ${PROVIDER_VERSION} --language dotnet --out sdk/
+	printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/dotnet/go.mod
+	@touch $@
+#{{- else }}#
 .make/generate_dotnet: .make/mise_install bin/$(CODEGEN)
 .make/generate_dotnet: | mise_env
 	$(GEN_ENVS) $(WORKING_DIR)/bin/$(CODEGEN) dotnet --out sdk/dotnet/
@@ -141,6 +148,7 @@ build_dotnet: .make/build_dotnet
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		echo "$(PROVIDER_VERSION)" >version.txt
 	@touch $@
+#{{- end }}#
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
@@ -148,10 +156,17 @@ build_dotnet: .make/build_dotnet
 
 generate_go: .make/generate_go
 build_go: .make/build_go
+#{{- if .Config.UseGoPackageGenSdk }}#
+.make/generate_go: .make/mise_install#{{- if not .Config.NoSchema }}# .make/schema#{{- end }}#
+.make/generate_go: | mise_env
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --version ${PROVIDER_VERSION} --language go --out sdk/
+	@touch $@
+#{{- else }}#
 .make/generate_go: .make/mise_install bin/$(CODEGEN)
 .make/generate_go: | mise_env
 	$(GEN_ENVS) $(WORKING_DIR)/bin/$(CODEGEN) go --out sdk/go/
 	@touch $@
+#{{- end }}#
 .make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
@@ -185,11 +200,19 @@ build_java: .make/build_java
 
 generate_nodejs: .make/generate_nodejs
 build_nodejs: .make/build_nodejs
+#{{- if .Config.UseNodejsPackageGenSdk }}#
+.make/generate_nodejs: .make/mise_install#{{- if not .Config.NoSchema }}# .make/schema#{{- end }}#
+.make/generate_nodejs: | mise_env
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --version ${PROVIDER_VERSION} --language nodejs --out sdk/
+	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	@touch $@
+#{{- else }}#
 .make/generate_nodejs: .make/mise_install bin/$(CODEGEN)
 .make/generate_nodejs: | mise_env
 	$(GEN_ENVS) $(WORKING_DIR)/bin/$(CODEGEN) nodejs --out sdk/nodejs/
 	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
 	@touch $@
+#{{- end }}#
 .make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
 		yarn install && \
@@ -200,12 +223,20 @@ build_nodejs: .make/build_nodejs
 
 generate_python: .make/generate_python
 build_python: .make/build_python
+#{{- if .Config.UsePythonPackageGenSdk }}#
+.make/generate_python: .make/mise_install#{{- if not .Config.NoSchema }}# .make/schema#{{- end }}#
+.make/generate_python: | mise_env
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --version ${PROVIDER_VERSION} --language python --out sdk/
+	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
+	@touch $@
+#{{- else }}#
 .make/generate_python: .make/mise_install bin/$(CODEGEN)
 .make/generate_python: | mise_env
 	$(GEN_ENVS) $(WORKING_DIR)/bin/$(CODEGEN) python --out sdk/python/
 	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
 	cp README.md sdk/python/
 	@touch $@
+#{{- end }}#
 .make/build_python: .make/generate_python
 	cd sdk/python/ && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -235,5 +235,17 @@ github-app:
 # Enables Java SDK generation via package gen-sdk
 useJavaPackageGenSdk: false
 
+# Enables Dotnet SDK generation via package gen-sdk
+useDotnetPackageGenSdk: false
+
+# Enables Go SDK generation via package gen-sdk
+useGoPackageGenSdk: false
+
+# Enables NodeJS SDK generation via package gen-sdk
+useNodejsPackageGenSdk: false
+
+# Enables Python SDK generation via package gen-sdk
+usePythonPackageGenSdk: false
+
 # Version of mise to use
 mise-version: 2026.2.15


### PR DESCRIPTION
Extends PR #2048 to add opt-in toggles for the remaining four SDK languages, enabling progressive migration from provider-specific codegen binaries to the unified `pulumi package gen-sdk` command.

Key changes:
- Add config fields: useDotnetPackageGenSdk, useGoPackageGenSdk, useNodejsPackageGenSdk, usePythonPackageGenSdk (all default to false)
- Update Makefile template with conditional logic for each language
- Schema dependency added (conditionally skipped for noSchema providers)
- Remove version.txt creation from Dotnet (handled via --version flag)
- Remove README.md copy from Python (embedded in schema)

Part of #2037