### PR TITLE
Fix merge queue auth

### DIFF
--- a/.github/workflows/deploy-infra-providers.yml
+++ b/.github/workflows/deploy-infra-providers.yml
@@ -2,6 +2,7 @@ permissions: write-all
 name: Deploy pulumi-provider-repos stack
 on:
   merge_group: {}
+  pull_request: {}
   workflow_dispatch: {}
 
 env:
@@ -45,7 +46,15 @@ jobs:
         run: pulumi stack select pulumi/pulumi-provider-repos/production
 
       - name: Pulumi up
+        if: github.event_name == 'merge_group'
         working-directory: infra/providers
         run: pulumi up --yes --skip-preview
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+
+      - name: Pulumi preview
+        if: github.event_name == 'pull_request'
+        working-directory: infra/providers
+        run: pulumi preview
         env:
           PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}


### PR DESCRIPTION
I didn't have the right branch protections in place before #2059 went in so it failed. This fixes the failure as well as the branch protections.