### PR TITLE
Add step to wait for GitHub rate limit to clear

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -80,6 +80,8 @@ jobs:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -86,6 +86,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -83,6 +83,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -88,6 +88,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -85,6 +85,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/pulumiservice/.config/mise.toml
+++ b/provider-ci/test-providers/pulumiservice/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -81,6 +81,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -71,6 +71,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -23,6 +23,7 @@ java = 'corretto-11'
 "aqua:gradle/gradle-distributions" = '7.6.6'
 golangci-lint = "1.64.8" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
+"wait-for-gh-rate-limit" = "1.1.1"
 
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -78,6 +78,8 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
+    - name: Wait for GitHub rate limit to clear
+      run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:


### PR DESCRIPTION
Part of: https://github.com/pulumi/home/issues/4527

Hypothesis: If we block in the prerequisites step until the end of the GitHub rate limit, then when execution resumes, we should be able to execute the workflow without rate limit errors.