### PR TITLE
Fail tests if provider-ci exits with non-zero

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /bin/bash -o pipefail
 NAME ?= all
 PROVIDERS := $(patsubst %/, %, $(wildcard providers/*/))
 PROVIDER_REPOS := $(addsuffix /repo, $(PROVIDERS))


### PR DESCRIPTION
While working on some `ci-mgmt` PRs, I started noticing that some files were marked with changes on git when my change was unrelated to them:

```
	modified:   test-providers/aws/.gitignore
	modified:   test-providers/cloudflare/.gitignore
	modified:   test-providers/docker/.gitignore
	modified:   test-providers/xyz/.gitignore
```

Those changes were related to @pgavlin's migration that adds:

```
# Don't ignore schema.go if it's part of the Go SDK
!sdk/go/**/schema.go
```

To each of those `.gitignore`s. 

My changes were, somehow, rolling back the migration. Since `make` didn't fail, I assumed that the tests were passing and there was something flaky on my environment compared to ci.

After having a closer look, I discovered that migrations were getting stuck at the  "Maintain golangci-lint config" migration but the error was not being propagated properly as make run successfully. Then, I discovered that the failure was being masked since it was part of a bash pipe command:

```
	find . -type f ! -name '.ci-mgmt.yaml' ! -name "*.go" ! -name 'go.mod' ! -name 'provider/go.mod' ! -name 'mise.toml'  ! -name '.golangci.yml' -delete && \
		../../bin/provider-ci generate 2>&1 | sed "s/^/[$(PROVIDER_NAME)] /"
```

By setting `SHELL=/bin/bash -o pipefail` on the `Makefile`, we should fail immediately  making it clear to the user that the migrations didn't run properly and there was a problem executing the make target.