### PR TITLE
Add gated schema generation via provider binary

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -349,6 +349,14 @@ type Config struct {
 	// UsePythonPackageGenSdk controls whether we use the Python SDK generation via package gen-sdk
 	UsePythonPackageGenSdk bool `yaml:"usePythonPackageGenSdk"`
 
+	// UseProviderBinarySchemaGen controls whether to use the provider binary
+	// directly for schema generation via "pulumi package get-schema" instead of
+	// the traditional codegen binary approach.
+	//
+	// Default: false (use traditional codegen binary)
+	// Set to true for providers that support dynamic schema generation.
+	UseProviderBinarySchemaGen bool `yaml:"useProviderBinarySchemaGen"`
+
 	// MiseVersion specifies the version of mise to use on GitHub Actions.
 	MiseVersion string `yaml:"mise-version"`
 }

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -328,8 +328,15 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+#{{- if .Config.UseProviderBinarySchemaGen }}#
+# New approach: No schema dependency (schema depends on provider instead)
+bin/$(PROVIDER):
+	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+#{{- else }}#
+# Traditional approach: Provider depends on schema (schema must exist first)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+#{{- end }}#
 .PHONY: provider provider_no_deps
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
@@ -359,11 +366,21 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+#{{- if .Config.UseProviderBinarySchemaGen }}#
+# New approach: Use provider binary directly for schema generation
+.make/schema: .make/mise_install .make/upstream
+.make/schema: bin/$(PROVIDER) | mise_env
+	pulumi package get-schema ./bin/$(PROVIDER) | \
+		jq 'del(.version)' > provider/cmd/$(PROVIDER)/schema.json
+	@touch $@
+#{{- else }}#
+# Traditional approach: Use codegen binary for schema generation
 .make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
 .make/schema: | mise_env
 	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
 	@touch $@
+#{{- end }}#
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): #{{ .Config.ModulePath }}#/*.go #{{ .Config.ModulePath }}#/go.* .make/upstream
 	(cd #{{ .Config.ModulePath }}# && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -238,6 +238,7 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+# Traditional approach: Provider depends on schema (schema must exist first)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
@@ -264,6 +265,7 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+# Traditional approach: Use codegen binary for schema generation
 .make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
 .make/schema: | mise_env
 	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -245,6 +245,7 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+# Traditional approach: Provider depends on schema (schema must exist first)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
@@ -271,6 +272,7 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+# Traditional approach: Use codegen binary for schema generation
 .make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
 .make/schema: | mise_env
 	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -250,6 +250,7 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+# Traditional approach: Provider depends on schema (schema must exist first)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
@@ -276,6 +277,7 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+# Traditional approach: Use codegen binary for schema generation
 .make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
 .make/schema: | mise_env
 	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -239,6 +239,7 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+# Traditional approach: Provider depends on schema (schema must exist first)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
@@ -265,6 +266,7 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+# Traditional approach: Use codegen binary for schema generation
 .make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
 .make/schema: | mise_env
 	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)

--- a/provider-ci/test-providers/pulumiservice/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/pulumiservice/.ci-mgmt.yaml
@@ -18,6 +18,7 @@ env:
 providerDefaultBranch: main
 template: generic
 shards: 6
+useProviderBinarySchemaGen: true
 esc:
     enabled: true
 modulePath: .

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -238,7 +238,8 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
-bin/$(PROVIDER): .make/schema
+# New approach: No schema dependency (schema depends on provider instead)
+bin/$(PROVIDER):
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
@@ -264,10 +265,11 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-.make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
-.make/schema: | mise_env
-	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)
-	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+# New approach: Use provider binary directly for schema generation
+.make/schema: .make/mise_install .make/upstream
+.make/schema: bin/$(PROVIDER) | mise_env
+	pulumi package get-schema ./bin/$(PROVIDER) | \
+		jq 'del(.version)' > provider/cmd/$(PROVIDER)/schema.json
 	@touch $@
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): ./*.go ./go.* .make/upstream

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -238,6 +238,7 @@ provider: bin/$(PROVIDER)
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
+# Traditional approach: Provider depends on schema (schema must exist first)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
@@ -264,6 +265,7 @@ tfgen_no_deps: .make/schema
 .make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 .make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 .make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+# Traditional approach: Use codegen binary for schema generation
 .make/schema: bin/$(CODEGEN) .make/mise_install .make/upstream
 .make/schema: | mise_env
 	$(WORKING_DIR)/bin/$(CODEGEN) schema --out provider/cmd/$(PROVIDER)


### PR DESCRIPTION
Part of https://github.com/pulumi/ci-mgmt/issues/2011

## Changes

Add new configuration flag `useProviderBinarySchemaGen` to enable providers to generate schema directly from the provider binary using `pulumi package get-schema` instead of the traditional codegen binary approach.

- Add `UseProviderBinarySchemaGen` config flag to config.go
- Update Makefile template with conditional logic for both approaches
- Enable flag for pulumiservice test provider as opt-in example

## Behavior

**When enabled (`useProviderBinarySchemaGen: true`):**
- `bin/$(PROVIDER)` no longer depends on `.make/schema`
- `.make/schema` depends on `bin/$(PROVIDER)` and uses `pulumi package get-schema`
- No circular dependency

**When disabled (default):**
- Traditional approach: `bin/$(CODEGEN)` generates schema
- Maintains backward compatibility for all existing providers

## Testing

- `make all` passes in provider-ci
- All 15 test providers regenerate successfully
- Pulumiservice uses new approach (opt-in via config flag)
- All other providers use traditional approach (default)
- Actionlint passes