### PR TITLE
Setup git identity in claude action

### DIFF
--- a/provider-ci/internal/pkg/templates/internal/.github/workflows/claude.yml
+++ b/provider-ci/internal/pkg/templates/internal/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/aws-native/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/aws/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/cloudflare/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/command/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/command/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/docker-build/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/docker/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/eks/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/kubernetes/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace

--- a/provider-ci/test-providers/xyz/.github/workflows/claude.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/claude.yml
@@ -64,6 +64,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # only saving the cache in the prerequisites job
           cache_save: false
+      - name: Set git identity
+        run: |-
+          git config user.name "claude[bot]"
+          git config user.email "bot@pulumi.com"
+        shell: bash
       - name: Prepare local workspace
         # this runs install_plugins and upstream
         run: make prepare_local_workspace


### PR DESCRIPTION
The upgrade-provider tool requires the git identity to be set in order to do things like apply patches.