### PR TITLE
Import pre-existing pulumiservice branch protection into Pulumi state

### DIFF
--- a/infra/providers/index.ts
+++ b/infra/providers/index.ts
@@ -16,6 +16,13 @@ const gh = new github.Provider("github", {
 // grab all the providers from their directory listing
 const tfProviders: string[] = JSON.parse(fs.readFileSync("../../provider-ci/providers.json", "utf-8"));
 
+// Providers whose branch protection rule pre-existed Pulumi management.
+// The node ID here is used to import the existing rule into state on the
+// first deployment rather than attempting to create a duplicate.
+const branchProtectionImports: Record<string, string> = {
+  pulumiservice: "BPR_kwDOHDpjg84BgNoo",
+};
+
 function tfProviderProtection(provider: string) {
   const requiredChecks: string[] = [
     // Sentinel is responsible for encapsulating CI checks.
@@ -50,6 +57,7 @@ function tfProviderProtection(provider: string) {
       provider: gh,
       retainOnDelete: true,
       deleteBeforeReplace: true,
+      import: branchProtectionImports[provider],
     },
   );
 


### PR DESCRIPTION
## Changes

Add `import` resource option to the `BranchProtection` created for `pulumiservice` in `infra/providers/index.ts`.

## Why

PR #2085 (adding `pulumiservice` to `providers.json`) fails the merge queue every time on the **Deploy provider repository settings** job. `pulumi-pulumiservice` already has a `main` branch protection rule (`BPR_kwDOHDpjg84BgNoo`) that was created outside of Pulumi. When the PR enters the merge queue, the workflow runs `pulumi up` (not just `preview`), which tries to create a duplicate rule and fails:

```
Name already protected: main (provider=github@6.10.1)
```

The `import` resource option tells Pulumi to adopt the existing rule into state on the first deployment rather than creating a new one. Subsequent runs just manage it normally.

## Related

- Fixes the merge queue failure blocking #2085