### PR TITLE
Add azure-native to providers list

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -10,6 +10,7 @@
     "aws-native",
     "awsx",
     "azure",
+    "azure-native",
     "azuread",
     "azuredevops",
     "cloudamqp",


### PR DESCRIPTION
Enables versioned documentation generation for azure-native in pulumi/registry.

Related: https://github.com/pulumi/registry/pull/10159