### PR TITLE
Fix test_provider scope: use . instead of ./... to avoid cmd/ build failures

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -353,7 +353,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 #{{- end }}#
 test_provider:
 	$(call test_provider_cmd)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -253,7 +253,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -260,7 +260,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -265,7 +265,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -254,7 +254,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -253,7 +253,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -253,7 +253,7 @@ test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
 	-coverprofile="coverage.txt" \
 	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
 	-parallel $(TESTPARALLELISM) \
-	./...
+	.
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider


### PR DESCRIPTION
Part of https://github.com/pulumi/ci-mgmt/issues/2106

## Problem

After #2107 was merged, several providers started failing CI with:

```
FAIL github.com/pulumi/pulumi-postgresql/provider/v3/cmd/pulumi-resource-postgresql [setup failed]
```

Affected providers:
- https://github.com/pulumi/pulumi-postgresql/issues/886
- https://github.com/pulumi/pulumi-newrelic/issues/1312
- https://github.com/pulumi/pulumi-auth0/issues/1098
- https://github.com/pulumi/pulumi-scm/issues/474

## Root Cause

The `cmd/pulumi-resource-*` packages embed a generated `schema.json` file (via `//go:embed`) that only exists after `make tfgen` runs. At test time in CI, this file does not exist.

The old workflow ran `go test .` (root package of `provider/` only), which never compiled the `cmd/` packages. After #2107, the `Run provider tests` step was changed to call `make test_provider`, which uses `./...` — and this is the first time the `cmd/` packages were compiled in CI, exposing the pre-existing build failure.

## Fix

Change `test_provider_cmd` from `./...` to `.` in the base Makefile template, restoring the original scope (root package of `provider/` only). The `cmd/` packages are binary entrypoints with no tests; they do not belong in the test scope.

## Test plan

- [ ] CI on this PR passes
- [ ] Re-run CI on one of the affected providers after this merges to confirm the fix

## Verification PRs

PRs created from branch `pose/fix/test-provider-scope` for the 21 providers with open sub-tickets:

- ❌ failed https://github.com/pulumi/pulumi-eks/pull/2193 (unrelated: issue with account limits for launch configurations https://github.com/pulumi/aws-account-cleanup/pull/116)
- ✅ passed https://github.com/pulumi/pulumi-sdwan/pull/460
- ✅ passed https://github.com/pulumi/pulumi-ise/pull/492
- ✅ passed https://github.com/pulumi/pulumi-snowflake/pull/1136
- ✅ passed https://github.com/pulumi/pulumi-cloudflare/pull/1521
- ❌ failed https://github.com/pulumi/pulumi-tls/pull/990 (unrelated: certificate issue pulumi/pulumi-tls#962)
- ✅ passed https://github.com/pulumi/pulumi-dbtcloud/pull/514
- ✅ passed https://github.com/pulumi/pulumi-datadog/pull/1115
- ✅ passed https://github.com/pulumi/pulumi-scm/pull/481
- ✅ passed https://github.com/pulumi/pulumi-digitalocean/pull/1295
- ✅ passed https://github.com/pulumi/pulumi-harness/pull/634
- ✅ passed https://github.com/pulumi/pulumi-gitlab/pull/1146
- ✅ passed https://github.com/pulumi/pulumi-random/pull/2027
- ✅ passed https://github.com/pulumi/pulumi-newrelic/pull/1321
- ✅ passed https://github.com/pulumi/pulumi-postgresql/pull/893
- ✅ passed https://github.com/pulumi/pulumi-auth0/pull/1105
- ✅ passed https://github.com/pulumi/pulumi-meraki/pull/508
- ✅ passed https://github.com/pulumi/pulumi-artifactory/pull/1298
- ✅ passed https://github.com/pulumi/pulumi-junipermist/pull/631
- ✅ passed https://github.com/pulumi/pulumi-okta/pull/1120
- ✅ passed https://github.com/pulumi/pulumi-pagerduty/pull/1048