### PR TITLE
fix: don't delete shared/ when cleaning GitHub workflows

### DIFF
--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -96,6 +96,12 @@ func GeneratePackage(opts GenerateOpts) error {
 	return nil
 }
 
+// workflowCleanAllowList contains workflow directory entries that should never
+// be deleted by cleanGithubWorkflows, regardless of naming convention.
+var workflowCleanAllowList = map[string]bool{
+	"shared": true,
+}
+
 func cleanGithubWorkflows(outDir string, providerName string) error {
 	workflows, err := os.ReadDir(filepath.Join(outDir, ".github", "workflows"))
 	if err != nil {
@@ -109,6 +115,10 @@ func cleanGithubWorkflows(outDir string, providerName string) error {
 	for _, workflow := range workflows {
 		// Skip provider-specific workflows which are prefixed with the provider name
 		if strings.HasPrefix(workflow.Name(), providerName+"-") {
+			continue
+		}
+		// Skip entries in the allow list (e.g. shared/)
+		if workflowCleanAllowList[workflow.Name()] {
 			continue
 		}
 		err = os.Remove(filepath.Join(outDir, ".github", "workflows", workflow.Name()))


### PR DESCRIPTION
## Summary

- `cleanGithubWorkflows` iterated over all entries in `.github/workflows/` and called `os.Remove` on anything not prefixed with the provider name
- This fails with `directory not empty` when a `shared/` subdirectory exists (as in `pulumi-aws`)
- Added a `workflowCleanAllowList` map so `shared/` (and any future entries) are explicitly skipped

Fixes #2114

## Test plan

- [x] `make all` passes (build, unit tests, test-providers, actionlint)
- [x] Verify workflow runs below succeed without deletion errors

## Verification runs

| Provider | Run | Result |
|---|---|---|
| aws | https://github.com/pulumi/ci-mgmt/actions/runs/23193177024 | ✅ |
| aws-apigateway | https://github.com/pulumi/ci-mgmt/actions/runs/23193178037 | ✅ |
| aws-native | https://github.com/pulumi/ci-mgmt/actions/runs/23193178958 | ✅ |
| awsx | https://github.com/pulumi/ci-mgmt/actions/runs/23193179860 | ✅ |
| azure | https://github.com/pulumi/ci-mgmt/actions/runs/23193180663 | ✅ |
| azuread | https://github.com/pulumi/ci-mgmt/actions/runs/23193181649 | ✅ |
| command | https://github.com/pulumi/ci-mgmt/actions/runs/23193182545 | ✅ |
| docker | https://github.com/pulumi/ci-mgmt/actions/runs/23193183426 | ✅ |
| docker-build | https://github.com/pulumi/ci-mgmt/actions/runs/23193184321 | ✅ |
| gcp | https://github.com/pulumi/ci-mgmt/actions/runs/23193185345 | ✅ |
| kubernetes | https://github.com/pulumi/ci-mgmt/actions/runs/23193186488 | ✅ |
| kubernetes-cert-manager | https://github.com/pulumi/ci-mgmt/actions/runs/23193187462 | ✅ |
| kubernetes-coredns | https://github.com/pulumi/ci-mgmt/actions/runs/23193188468 | ✅ |
| kubernetes-ingress-nginx | https://github.com/pulumi/ci-mgmt/actions/runs/23193189411 | ✅ |
| provider-boilerplate | https://github.com/pulumi/ci-mgmt/actions/runs/23193190490 | ✅ |
| std | https://github.com/pulumi/ci-mgmt/actions/runs/23193191345 | ✅ |
| terraform | https://github.com/pulumi/ci-mgmt/actions/runs/23193192461 | ✅ |
| terraform-module | https://github.com/pulumi/ci-mgmt/actions/runs/23193193432 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)