### PR TITLE
Fix pulumiservice test-provider: add testProviderCmd override

### DIFF
--- a/provider-ci/test-providers/pulumiservice/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/pulumiservice/.ci-mgmt.yaml
@@ -19,6 +19,12 @@ providerDefaultBranch: main
 template: generic
 shards: 6
 useProviderBinarySchemaGen: true
+testProviderCmd: >-
+  cd provider && $(GO_TEST_EXEC) -v -short
+  -coverprofile="coverage.txt"
+  -coverpkg="./...,github.com/hashicorp/terraform-provider-..."
+  -parallel $(TESTPARALLELISM)
+  ./pkg/...
 esc:
     enabled: true
 modulePath: .

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -249,11 +249,7 @@ test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)
 .PHONY: test
-test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
-	-coverprofile="coverage.txt" \
-	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
-	-parallel $(TESTPARALLELISM) \
-	.
+test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short -coverprofile="coverage.txt" -coverpkg="./...,github.com/hashicorp/terraform-provider-..." -parallel $(TESTPARALLELISM) ./pkg/...
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider


### PR DESCRIPTION
## Summary

- `pulumi-pulumiservice` is a native Go provider whose `provider/` directory has no Go source files (only `cmd/` and `pkg/` subdirectories)
- After #2113 changed `test_provider_cmd` from `./...` to `.`, `go test .` fails with `FAIL . [setup failed]`
- Added `testProviderCmd` override using `./pkg/...` to test the `pkg/` subtree while skipping `cmd/`
- Syncs the test-provider config with pulumi/pulumi-pulumiservice#730

## Test plan

- [x] `make test-provider/pulumiservice` passes (including actionlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>