### PR TITLE
Fix golangci-lint v2 rollout failures

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/internal/pkg/templates/all/.golangci.yml
+++ b/provider-ci/internal/pkg/templates/all/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -296,17 +296,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/aws-native/.golangci.yml
+++ b/provider-ci/test-providers/aws-native/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/aws/.golangci.yml
+++ b/provider-ci/test-providers/aws/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -217,17 +217,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/cloudflare/.golangci.yml
+++ b/provider-ci/test-providers/cloudflare/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -224,17 +224,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/command/.golangci.yml
+++ b/provider-ci/test-providers/command/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/docker-build/.golangci.yml
+++ b/provider-ci/test-providers/docker-build/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/docker/.golangci.yml
+++ b/provider-ci/test-providers/docker/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -229,17 +229,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/eks/.golangci.yml
+++ b/provider-ci/test-providers/eks/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -218,17 +218,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/kubernetes-cert-manager/.golangci.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/kubernetes-coredns/.golangci.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.golangci.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/kubernetes/.golangci.yml
+++ b/provider-ci/test-providers/kubernetes/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.golangci.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/pulumiservice/.config/mise.toml
+++ b/provider-ci/test-providers/pulumiservice/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/pulumiservice/.golangci.yml
+++ b/provider-ci/test-providers/pulumiservice/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -217,17 +217,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/terraform-module/.golangci.yml
+++ b/provider-ci/test-providers/terraform-module/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -21,7 +21,7 @@ java = 'corretto-11'
 "github:pulumi/schema-tools" = "0.6.0"
 "go:github.com/pulumi/upgrade-provider" = "main"
 "aqua:gradle/gradle-distributions" = '7.6.6'
-golangci-lint = "2.2.2" # See note about about overrides if you need to customize this.
+golangci-lint = "2.9.0" # See note about about overrides if you need to customize this.
 "npm:yarn" = "1.22.22"
 
 [settings]

--- a/provider-ci/test-providers/xyz/.golangci.yml
+++ b/provider-ci/test-providers/xyz/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     rules:
       - linters:
           - revive
-        path: pkg/version/
+        path: pkg/
         text: "var-naming" # https://github.com/pulumi/ci-mgmt/issues/2100
 formatters:
   enable:

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -217,17 +217,17 @@ install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
 lint: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 # `lint.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix: upstream
-	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
+	if git grep -ql 'go:embed' -- provider; then git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'; fi
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix; LINT_EXIT=$$?; \
-	git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; \
+	if git grep -ql 'goembed'; then git grep -l 'goembed' | xargs perl -i -pe 's/ goembed/go:embed/g'; fi; \
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix


### PR DESCRIPTION
## Summary

Follow-up to #2128 fixing three classes of failures discovered during rollout.

- **Bump golangci-lint `2.2.2` → `2.9.0`** — golangci-lint 2.2.2 was built with Go 1.25 and refuses to lint providers targeting Go 1.26.1+ (`can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.1)`).
  - pulumi/pulumi-ec#760 ([log](https://github.com/pulumi/pulumi-ec/actions/runs/24435836142/job/71390713972#step:7:36))
  - pulumi/pulumi-gitlab#1164 ([log](https://github.com/pulumi/pulumi-gitlab/actions/runs/24435870296/job/71390414096#step:7:36))

- **Broaden `revive: var-naming` exclusion from `pkg/version/` to `pkg/`** — `revive` flags common package names (`util`, `helpers`, `common`, `version`, etc.) in `pkg/` subdirectories as meaningless.
  - pulumi/pulumi-pulumiservice#741 ([log](https://github.com/pulumi/pulumi-pulumiservice/actions/runs/24440157373/job/71403838727#step:7:9))

- **Guard `xargs perl` in Makefile with `if git grep -ql`** — when a provider has no `go:embed` files, `git grep` returns empty and `xargs perl -i` with empty stdin reads from stdin and hangs/fails.
  - pulumi/pulumi-aws-apigateway#687 ([log](https://github.com/pulumi/pulumi-aws-apigateway/actions/runs/24438623593/job/71399494470#step:7:41))

## Not in scope

- pulumi/pulumi-terraform-module#794 — staticcheck failures (ST1005, QF1008) are real code issues in the provider; fixed in pulumi/pulumi-terraform-module#795.

## Test plan

- [x] `cd provider-ci && make all` passes cleanly
- [x] All 15 test providers regenerate deterministically
- [x] Downstream verification for affected providers:
  - pulumi-ec: [run](https://github.com/pulumi/ci-mgmt/actions/runs/24461968069) → pulumi/pulumi-ec#765 ✅
  - pulumi-gitlab: [run](https://github.com/pulumi/ci-mgmt/actions/runs/24461969226) → pulumi/pulumi-gitlab#1166 ✅
  - pulumi-pulumiservice: [run](https://github.com/pulumi/ci-mgmt/actions/runs/24461970645) → pulumi/pulumi-pulumiservice#742 ✅
  - pulumi-aws-apigateway: [run](https://github.com/pulumi/ci-mgmt/actions/runs/24461972069) → pulumi/pulumi-aws-apigateway#688 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)