### PR TITLE
Add `integrationTestCoverage` opt-in for native providers

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -237,8 +237,8 @@ type Config struct {
 	// binary with coverage (`go build -cover`) for the SDK integration test
 	// matrix and uploading the resulting profile to Codecov. Requires the
 	// repo's Makefile to define a `provider_cover` target that produces the
-	// instrumented binary at the same path as `make provider`. (Native
-	// providers only.)
+	// instrumented binary at the same path as `make provider`. Supported by
+	// the `native` and `generic` templates.
 	IntegrationTestCoverage bool `yaml:"integrationTestCoverage"`
 
 	// PulumiVersionFile specifies the file to read the Pulumi version from.

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -233,6 +233,14 @@ type Config struct {
 	// SetupKind controls whether to setup a KinD cluster. (only used in kubernetes-coredns)
 	SetupKind bool `yaml:"setupKind"`
 
+	// IntegrationTestCoverage opts the provider into instrumenting the provider
+	// binary with coverage (`go build -cover`) for the SDK integration test
+	// matrix and uploading the resulting profile to Codecov. Requires the
+	// repo's Makefile to define a `provider_cover` target that produces the
+	// instrumented binary at the same path as `make provider`. (Native
+	// providers only.)
+	IntegrationTestCoverage bool `yaml:"integrationTestCoverage"`
+
 	// PulumiVersionFile specifies the file to read the Pulumi version from.
 	PulumiVersionFile string `yaml:"pulumiVersionFile"`
 

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -113,6 +120,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -105,7 +105,7 @@ jobs:
       run: make build_registry_docs
     #{{- end }}#
     - name: Build provider binary
-      run: make provider
+      run: #{{ if .Config.IntegrationTestCoverage }}#make provider_cover#{{ else }}#make provider#{{ end }}#
     - name: Unit-test provider code
       run: make test_provider
       env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -43,6 +43,9 @@ jobs:
       id-token: write # For ESC secrets.
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      #{{- if .Config.IntegrationTestCoverage }}#
+      cover: true
+      #{{- end }}#
       matrix: |
         {
           "platform": [

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -163,6 +163,10 @@ jobs:
     - name: Install prebuilt SDKs
       run: make install_sdks
 #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
+    #{{- end }}#
 #{{- if not .Config.Shards }}#
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
@@ -172,20 +176,29 @@ jobs:
     #{{- if .Config.IntegrationTestProvider }}#
     - name: Run provider tests
       if: matrix.testTarget == 'local'
-      run: make TESTTAGS=${{ matrix.language }} GOTESTARGS="-count=1 -cover" test_provider
+      run: make TESTTAGS=${{ matrix.language }} GOTESTARGS="-count=1#{{ if not .Config.IntegrationTestCoverage }}# -cover#{{ end }}#" test_provider
       env:
 #{{ .Config | renderLocalEnv | indent 8 }}#
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
     #{{- end }}#
     - name: Run tests
       if: matrix.testTarget == 'local'
-      run: make TESTTAGS=${{ matrix.language }} GOTESTARGS="-count=1 -cover -skip TestPulumiExamples" test
+      run: make TESTTAGS=${{ matrix.language }} GOTESTARGS="-count=1#{{ if not .Config.IntegrationTestCoverage }}# -cover#{{ end }}# -skip TestPulumiExamples" test
       env:
 #{{ .Config | renderLocalEnv | indent 8 }}#
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
-      run: make TESTTAGS=${{ matrix.language }} GOTESTARGS="-count=1 -cover -run TestPulumiExamples" test
+      run: make TESTTAGS=${{ matrix.language }} GOTESTARGS="-count=1#{{ if not .Config.IntegrationTestCoverage }}# -cover#{{ end }}# -run TestPulumiExamples" test
       env:
 #{{ .Config | renderLocalEnv | indent 8 }}#
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
 #{{- else }}#
 #{{- if .Config.Actions.PreTest }}#
 #{{ .Config.Actions.PreTest | toYaml | indent 4 }}#
@@ -202,7 +215,24 @@ jobs:
         make GOTESTARGS="-test.run ${SHARD_TESTS} ${SHARD_PATHS}" test
       env:
 #{{ .Config | renderLocalEnv | indent 8 }}#
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
 #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-integration.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: #{{ .Config.ActionVersions.Codecov }}#
+      with:
+        files: ${{ github.workspace }}/coverage-integration.out
+        flags: integration#{{ if .Config.Shards }}#-shard-${{ matrix.current-shard }}#{{ else }}#-${{ matrix.language }}-${{ matrix.testTarget }}#{{ end }}#
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+    #{{- end }}#
     strategy:
       fail-fast: false
 #{{- if .Config.Shards }}#

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -341,6 +341,15 @@ bin/$(PROVIDER): .make/schema
 #{{- end }}#
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd #{{ .Config.TestFolder }}# && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -320,7 +320,7 @@ build_provider_cmd = #{{ if .Config.BuildProviderPre -}}#
 build_provider_cmd = #{{ if .Config.BuildProviderPre -}}#
                          #{{ .Config.BuildProviderPre }}#;
                      #{{- end -}}#
-                     cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+                     cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) $(PROVIDER_BUILD_FLAGS) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 #{{- end }}#
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -431,6 +431,18 @@ jobs:
         2h -parallel 4 ./...
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #{{- else if .Config.IntegrationTestCoverage }}#
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
+    - name: Run tests
+      run: >-
+        set -euo pipefail
+
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
     #{{- else }}#
     - name: Run tests
       run: >-
@@ -439,9 +451,6 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #{{- if .Config.IntegrationTestCoverage }}#
-        GOCOVERDIR: ${{ github.workspace }}/coverage
-        #{{- end }}#
     #{{- end }}#
     #{{- if .Config.IntegrationTestCoverage }}#
     - name: Convert coverage data

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
     #{{- end }}#
     #{{- if ne .Config.Provider "kubernetes" }}#
     - name: Build Provider
-      run: make provider
+      run: #{{ if .Config.IntegrationTestCoverage }}#make provider_cover#{{ else }}#make provider#{{ end }}#
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
@@ -421,6 +421,10 @@ jobs:
         node_image: kindest/node:v1.29.2
         config: kind.config.yml
     #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
+    #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
@@ -435,6 +439,23 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
+    #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     #{{- end }}#
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -391,6 +391,18 @@ jobs:
         2h -parallel 4 ./...
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #{{- else if .Config.IntegrationTestCoverage }}#
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
+    - name: Run tests
+      run: >-
+        set -euo pipefail
+
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
     #{{- else }}#
     - name: Run tests
       run: >-
@@ -399,9 +411,6 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #{{- if .Config.IntegrationTestCoverage }}#
-        GOCOVERDIR: ${{ github.workspace }}/coverage
-        #{{- end }}#
     #{{- end }}#
     #{{- if .Config.IntegrationTestCoverage }}#
     - name: Convert coverage data

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -110,7 +110,7 @@ jobs:
     #{{- end }}#
     #{{- if ne .Config.Provider "kubernetes" }}#
     - name: Build Provider
-      run: make provider
+      run: #{{ if .Config.IntegrationTestCoverage }}#make provider_cover#{{ else }}#make provider#{{ end }}#
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
@@ -381,6 +381,10 @@ jobs:
         node_image: kindest/node:v1.29.2
         config: kind.config.yml
     #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
+    #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
@@ -395,6 +399,23 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
+    #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     #{{- end }}#
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -393,6 +393,18 @@ jobs:
         2h -parallel 4 ./...
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #{{- else if .Config.IntegrationTestCoverage }}#
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
+    - name: Run tests
+      run: >-
+        set -euo pipefail
+
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+      env:
+        GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
     #{{- else }}#
     - name: Run tests
       run: >-
@@ -401,9 +413,6 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #{{- if .Config.IntegrationTestCoverage }}#
-        GOCOVERDIR: ${{ github.workspace }}/coverage
-        #{{- end }}#
     #{{- end }}#
     #{{- if .Config.IntegrationTestCoverage }}#
     - name: Convert coverage data

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
     #{{- end }}#
     #{{- if ne .Config.Provider "kubernetes" }}#
     - name: Build Provider
-      run: make provider
+      run: #{{ if .Config.IntegrationTestCoverage }}#make provider_cover#{{ else }}#make provider#{{ end }}#
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
@@ -383,6 +383,10 @@ jobs:
         node_image: kindest/node:v1.29.2
         config: kind.config.yml
     #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
+    #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
@@ -397,6 +401,23 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
+    #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     #{{- end }}#
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -138,7 +138,7 @@ jobs:
     #{{- end }}#
     #{{- if ne .Config.Provider "kubernetes" }}#
     - name: Build Provider
-      run: make provider
+      run: #{{ if .Config.IntegrationTestCoverage }}#make provider_cover#{{ else }}#make provider#{{ end }}#
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
@@ -524,6 +524,10 @@ jobs:
         node_image: kindest/node:v1.29.2
         config: kind.config.yml
     #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
+    #{{- end }}#
     #{{- if eq .Config.Provider "kubernetes" }}#
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
@@ -538,6 +542,23 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #{{- if .Config.IntegrationTestCoverage }}#
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+        #{{- end }}#
+    #{{- end }}#
+    #{{- if .Config.IntegrationTestCoverage }}#
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     #{{- end }}#
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -534,6 +534,18 @@ jobs:
         2h -parallel 4 -short ./...
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #{{- else if .Config.IntegrationTestCoverage }}#
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
+    - name: Run tests
+      run: >-
+        set -euo pipefail
+
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
     #{{- else }}#
     - name: Run tests
       run: >-
@@ -542,9 +554,6 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #{{- if .Config.IntegrationTestCoverage }}#
-        GOCOVERDIR: ${{ github.workspace }}/coverage
-        #{{- end }}#
     #{{- end }}#
     #{{- if .Config.IntegrationTestCoverage }}#
     - name: Convert coverage data

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -113,6 +120,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -245,6 +245,15 @@ bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -231,7 +231,7 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh;cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh;cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) $(PROVIDER_BUILD_FLAGS) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -112,6 +119,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -252,6 +252,15 @@ bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -238,7 +238,7 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) $(PROVIDER_BUILD_FLAGS) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/command/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/command/.ci-mgmt.yaml
@@ -7,6 +7,7 @@ providerDefaultBranch: main
 parallel: 3
 timeout: 0.0000001
 noSchema: true # Disable schema check.
+integrationTestCoverage: true
 envOverride:
   AWS_REGION: us-west-2
   PULUMI_API: https://api.pulumi-staging.io

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -313,11 +313,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -311,6 +311,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -318,6 +320,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -269,11 +269,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -267,6 +267,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -274,6 +276,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -267,6 +267,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -274,6 +276,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -269,11 +269,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GTIHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
-      run: make provider
+      run: make provider_cover
     - name: Check worktree clean
       id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
@@ -418,6 +418,8 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -425,6 +427,19 @@ jobs:
         cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-${{ matrix.language }}.out
+        flags: integration-${{ matrix.language }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -420,11 +420,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare coverage directory
       run: mkdir -p ${{ github.workspace }}/coverage
+    # `go test -cover` would override the test process's GOCOVERDIR with a
+    # private tmpdir, which then gets inherited (and discarded) by the
+    # provider subprocess. Omit -cover so the env var we set below sticks.
     - name: Run tests
       run: >-
         set -euo pipefail
 
-        cd examples && go test -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+        cd examples && go test -count=1 -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOCOVERDIR: ${{ github.workspace }}/coverage

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -104,6 +111,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -257,6 +257,15 @@ bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -243,7 +243,7 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) $(PROVIDER_BUILD_FLAGS) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -104,6 +111,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -246,6 +246,15 @@ bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd tests && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/test-providers/pulumiservice/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/pulumiservice/.ci-mgmt.yaml
@@ -17,6 +17,7 @@ env:
   PULUMI_TEST_USE_SERVICE: true
 providerDefaultBranch: main
 template: generic
+integrationTestCoverage: true
 shards: 6
 useProviderBinarySchemaGen: true
 testProviderCmd: >-

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -104,6 +111,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Generate schema
       run: make schema
     - name: Build provider binary
-      run: make provider
+      run: make provider_cover
     - name: Unit-test provider code
       run: make test_provider
       env:

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/run-acceptance-tests.yml
@@ -52,6 +52,7 @@ jobs:
       id-token: write # For ESC secrets.
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      cover: true
       matrix: |
         {
           "platform": [

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/test.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/test.yml
@@ -106,6 +106,8 @@ jobs:
         pip3 install pipenv
     - name: Install prebuilt SDKs
       run: make install_sdks
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Generate test shards
       run: |-
         cd examples
@@ -119,6 +121,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_STAGING }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-integration.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-integration.out
+        flags: integration-shard-${{ matrix.current-shard }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -245,6 +245,15 @@ bin/$(PROVIDER):
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -101,6 +108,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/xyz/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -104,6 +111,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -245,6 +245,15 @@ bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -231,7 +231,7 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) $(PROVIDER_BUILD_FLAGS) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 


### PR DESCRIPTION
## Summary

Wires up runtime coverage collection from the SDK integration test matrix for native providers that opt in via `integrationTestCoverage: true` in their `.ci-mgmt.yaml`.

When enabled, the generated workflow:

1. Builds the provider with `make provider_cover` instead of `make provider`. The new target invokes `go build -cover -covermode=atomic`, which produces a binary that writes coverage data files to `\$GOCOVERDIR` whenever it exits.
2. Sets `GOCOVERDIR` on the integration test step so each invocation of the provider (spawned by the Pulumi engine as a subprocess) emits coverage data into a shared directory.
3. After tests finish, runs `go tool covdata textfmt` to convert the collected data into a coverage profile and uploads it to Codecov under an `integration-<language>` flag so the matrix shards merge.

The opt-in is gated so there is no behaviour change for existing providers. Test fixture coverage in \`provider-ci/test-providers/command/\` shows the rendered workflow with the flag enabled.

## Motivation

Today, Codecov for native providers only reflects coverage from `make test_provider` (Go unit tests). The SDK integration matrix runs the actual provider binary as a subprocess but contributes nothing to coverage, so patches whose new code is exercised end-to-end (e.g. CRUD paths driven through the Pulumi engine) show artificially low patch coverage.

Go 1.20+ supports `go build -cover` to instrument binaries; this PR plumbs it through the workflow and Codecov upload.

## Caveats

- The `provider_cover` target is added to the base Makefile template, so providers that use the templated Makefile pick it up automatically. Native providers (\`command\`, \`pulumiservice\`, etc.) have hand-written Makefiles and must add the target locally for the workflow to invoke it. This is documented in the new field's godoc.
- The workflow only enables this for the matrix \`test\` job, not the \`prerequisites\` \`Test Provider Library\` step (that step already produces \`coverage.txt\` from \`make test_provider\`).

## Test plan

- [x] `make test-providers` regenerates fixtures and passes actionlint.
- [x] `provider-ci/test-providers/command/` fixtures show the new steps under the opt-in flag; other test providers are untouched aside from the new `provider_cover` target appearing in their Makefile fixtures.
- [ ] Wire a downstream provider PR (\`pulumi-command\`) that opts in and observe Codecov reflecting integration coverage.