### PR TITLE
Support allow-major provider upgrade config

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22upstream-provider-repo%22&type=code
 	UpstreamProviderRepo string `yaml:"upstream-provider-repo"`
 
+	// DisableMajorProviderUpgrades is used in the bridge upgrade config to prevent
+	// upgrade-provider from crossing major upstream version boundaries.
+	DisableMajorProviderUpgrades bool `yaml:"disableMajorProviderUpgrades"`
+
 	// Lint includes an extra lint job in workflows if enabled (default). Can
 	// be explicitly set to false. This is false in around 8 provider repos:
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22lint%3A+false%22&type=code

--- a/provider-ci/internal/pkg/config_test.go
+++ b/provider-ci/internal/pkg/config_test.go
@@ -1,0 +1,43 @@
+package pkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadLocalConfigDefaultsMajorProviderUpgradesEnabled(t *testing.T) {
+	dir := t.TempDir()
+
+	configPath := filepath.Join(dir, ".ci-mgmt.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: aws\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadLocalConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.DisableMajorProviderUpgrades {
+		t.Fatal("expected major provider upgrades to be enabled by default")
+	}
+}
+
+func TestLoadLocalConfigCanDisableMajorProviderUpgrades(t *testing.T) {
+	dir := t.TempDir()
+
+	configPath := filepath.Join(dir, ".ci-mgmt.yaml")
+	if err := os.WriteFile(configPath, []byte(`provider: aws
+disableMajorProviderUpgrades: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadLocalConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !config.DisableMajorProviderUpgrades {
+		t.Fatal("expected local config to disable major provider upgrades")
+	}
+}

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -36,6 +36,10 @@ major-version: 2
 # Only set for 5 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22upstream-provider-repo%22&type=code
 #upstream-provider-repo: terraform-provider-xyz
 
+# disableMajorProviderUpgrades is used in the bridge upgrade config. When true, upgrade-provider will not
+# cross major upstream version boundaries.
+disableMajorProviderUpgrades: false
+
 # Customizes the name of the "gen" program.
 # Defaults to "tfgen" for bridged providers and "gen" for generic providers.
 #genName: tfgen

--- a/provider-ci/internal/pkg/templates/internal-bridged/.upgrade-config.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.upgrade-config.yml
@@ -9,5 +9,8 @@ upstream-provider-name: terraform-provider-#{{ .Config.Provider }}#
 #{{- if .Config.UpstreamProviderOrg }}#
 upstream-provider-org: #{{ .Config.UpstreamProviderOrg }}#
 #{{- end }}#
+#{{- if not .Config.DisableMajorProviderUpgrades }}#
+allow-major: true
+#{{- end }}#
 pulumi-infer-version: true
 remove-plugins: true

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -1,4 +1,5 @@
 provider: aws
+disableMajorProviderUpgrades: true
 lint: false
 major-version: 7
 parallel: 1

--- a/provider-ci/test-providers/cloudflare/.upgrade-config.yml
+++ b/provider-ci/test-providers/cloudflare/.upgrade-config.yml
@@ -2,5 +2,6 @@
 
 ---
 upstream-provider-name: terraform-provider-cloudflare
+allow-major: true
 pulumi-infer-version: true
 remove-plugins: true

--- a/provider-ci/test-providers/docker/.upgrade-config.yml
+++ b/provider-ci/test-providers/docker/.upgrade-config.yml
@@ -3,5 +3,6 @@
 ---
 upstream-provider-name: terraform-provider-docker
 upstream-provider-org: kreuzwerker
+allow-major: true
 pulumi-infer-version: true
 remove-plugins: true

--- a/provider-ci/test-providers/xyz/.upgrade-config.yml
+++ b/provider-ci/test-providers/xyz/.upgrade-config.yml
@@ -2,5 +2,6 @@
 
 ---
 upstream-provider-name: terraform-provider-xyz
+allow-major: true
 pulumi-infer-version: true
 remove-plugins: true


### PR DESCRIPTION
## Summary
- add `disableMajorProviderUpgrades` to `.ci-mgmt.yaml` config, defaulting to `false`
- render `allow-major: true` in generated `.upgrade-config.yml` unless `disableMajorProviderUpgrades: true` is set
- remove the embedded provider-defaults approach and keep the behavior on the existing global defaults path
- cover default-enabled and repo-local-disable behavior in unit tests

## Context
This wires ci-mgmt generation to the new `allow-major` upgrade-provider config from pulumi/upgrade-provider#372. Major provider upgrades are now allowed by default for generated internal bridged provider upgrade configs; individual provider repos can opt out with `disableMajorProviderUpgrades: true` in `.ci-mgmt.yaml`.

## Testing
- `cd provider-ci && make all`

## Follow up

Need to follow up this with setting `disableMajorProviderUpgrades: true` on the following providers:

- `aws`
- `gcp`
- `azure`
- `azuread`
- `cloudflare`
- `random`
- `tls`

closes https://github.com/pulumi/home/issues/4562