### PR TITLE
Refactor bridged acceptance workflow ordering

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"
@@ -80,6 +84,26 @@ jobs:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         # only saving the cache in the prerequisites job
         cache_save: true
+    #{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout == false
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
+      with:
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
+          sdk/go/*.sum
+          sdk/*.sum
+          *.sum
+    #{{- else }}#
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
@@ -89,6 +113,7 @@ jobs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
+    #{{- end }}#
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:
@@ -96,6 +121,87 @@ jobs:
 #{{- if .Config.Actions.PreBuild }}#
 #{{ .Config.Actions.PreBuild | toYaml | indent 4 }}#
 #{{- end }}#
+    #{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
+    - name: Generate schema-embed
+      if: inputs.acceptance_fanout
+      run: make schema_embed
+    - name: Build tfgen
+      if: inputs.acceptance_fanout
+      run: make tfgen_build_only
+    #{{- if not .Config.NoSchema }}#
+    - name: Generate schema
+      if: inputs.acceptance_fanout == false
+      run: make schema
+    #{{- end }}#
+    #{{- if .Config.RegistryDocs }}#
+    - name: Build registry docs
+      if: inputs.acceptance_fanout == false
+      run: make build_registry_docs
+    #{{- end }}#
+    - name: Build provider binary
+      if: inputs.acceptance_fanout == false
+      run: make provider
+    - name: Unit-test provider code
+      if: inputs.acceptance_fanout == false
+      run: make test_provider
+      env:
+#{{ .Config | renderLocalEnv | indent 8 }}#
+    - name: Upload coverage reports to Codecov
+      if: inputs.acceptance_fanout == false
+      uses: #{{ .Config.ActionVersions.Codecov }}#
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+#{{- if not .Config.NoSchema }}#
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: #{{ .Config.ActionVersions.PrComment }}#
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+#{{- if .Config.EnableConfigurationCheck }}#
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false
+      name: Check for missing config
+      run: |
+        if [ ! -z "${{ env.MISSING_CONFIG }}" ]; then
+        cat <<EOF
+        ${{ env.MISSING_CONFIG }}
+        EOF
+        echo 'Please add a description for each of these options to `README.md`.'
+        echo 'Details about them can be found in either the upstream docs or `schema.json`.'
+        exit 1
+        fi
+#{{- end }}#
+#{{- end }}#
+    #{{- else }}#
     #{{- if not .Config.NoSchema }}#
     - name: Generate schema
       run: make schema
@@ -162,6 +268,7 @@ jobs:
         echo 'Details about them can be found in either the upstream docs or `schema.json`.'
         exit 1
         fi
+#{{- end }}#
 #{{- end }}#
 #{{- end }}#
 

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -33,6 +33,9 @@ jobs:
       default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
+      #{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
+      acceptance_fanout: true
+      #{{- end }}#
 
   build_provider:
     uses: ./.github/workflows/build_provider.yml
@@ -50,6 +53,197 @@ jobs:
             {"os": "windows", "arch": "amd64"}
           ]
         }
+
+#{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
+
+  test_provider:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: #{{ .Config.Runner.Prerequisites }}#
+    needs: prerequisites
+    permissions:
+      contents: read
+      id-token: write # For ESC secrets.
+    steps:
+    #{{- if .Config.FreeDiskSpaceBeforeBuild }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: #{{ .Config.ActionVersions.FreeDiskSpace }}#
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+    #{{- end }}#
+    - name: Checkout Repo
+      uses: #{{ .Config.ActionVersions.Checkout }}#
+      with:
+        #{{- if .Config.CheckoutSubmodules }}#
+        submodules: #{{ .Config.CheckoutSubmodules }}#
+        #{{- end }}#
+        persist-credentials: false
+#{{ .Config | renderEscStep | trimPrefix "\n" | indent 4 }}#
+#{{- if .Config.GitHubApp.Enabled }}#
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+#{{- end }}#
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: #{{ .Config.MiseVersion }}#
+        github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Unit-test provider code
+      run: make test_provider
+      env:
+#{{ .Config | renderLocalEnv | indent 8 }}#
+    - name: Upload coverage reports to Codecov
+      uses: #{{ .Config.ActionVersions.Codecov }}#
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+
+  build_schema:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: #{{ .Config.Runner.Prerequisites }}#
+    needs: prerequisites
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # For ESC secrets.
+    steps:
+    #{{- if .Config.FreeDiskSpaceBeforeBuild }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: #{{ .Config.ActionVersions.FreeDiskSpace }}#
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+    #{{- end }}#
+    - name: Checkout Repo
+      uses: #{{ .Config.ActionVersions.Checkout }}#
+      with:
+        #{{- if .Config.CheckoutSubmodules }}#
+        submodules: #{{ .Config.CheckoutSubmodules }}#
+        #{{- end }}#
+        persist-credentials: false
+#{{ .Config | renderEscStep | trimPrefix "\n" | indent 4 }}#
+#{{- if .Config.GitHubApp.Enabled }}#
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+#{{- end }}#
+    - name: Cache examples generation
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: #{{ .Config.MiseVersion }}#
+        github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Restore makefile progress
+      run: make --touch provider
+    - name: Generate schema
+      run: make schema
+      env:
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    #{{- if .Config.RegistryDocs }}#
+    - name: Build registry docs
+      run: make build_registry_docs
+    #{{- end }}#
+    - name: Check worktree clean
+      id: worktreeClean
+      uses: pulumi/git-status-check-action@v1
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: #{{ .Config.ActionVersions.PrComment }}#
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+#{{- if .Config.EnableConfigurationCheck }}#
+    - if: github.event_name == 'pull_request'
+      name: Check Configuration section
+      run: |
+        sed -n '/## Configuration/,$p' README.md | sed -n '/## Reference/q;p' >> config_section.txt
+        jq -r '.config | select(.variables) | .variables | keys[]' < provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json >> keys.txt
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "MISSING_CONFIG<<$EOF";
+          xargs -I {} sh -c "grep -q {} config_section.txt || echo \\\`{}\\\` not found in Configuration section" < keys.txt
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Check for missing config
+      run: |
+        if [ ! -z "${{ env.MISSING_CONFIG }}" ]; then
+        cat <<EOF
+        ${{ env.MISSING_CONFIG }}
+        EOF
+        echo 'Please add a description for each of these options to `README.md`.'
+        echo 'Details about them can be found in either the upstream docs or `schema.json`.'
+        exit 1
+        fi
+#{{- end }}#
+#{{- end }}#
 
   #{{ if not .Config.NoSchema -}}#
   build_sdk:
@@ -105,6 +299,10 @@ jobs:
     needs:
     - test
     - build_provider
+    #{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
+    - build_schema
+    - test_provider
+    #{{- end }}#
     - license_check
     #{{- if .Config.Lint }}#
     - lint

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -414,7 +414,11 @@ tfgen_no_deps: .make/schema
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): #{{ .Config.ModulePath }}#/*.go #{{ .Config.ModulePath }}#/go.* .make/upstream
 	(cd #{{ .Config.ModulePath }}# && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+#{{- if not .Config.UseProviderBinarySchemaGen }}#
+schema_embed:
+	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+#{{- end }}#
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only#{{ if not .Config.UseProviderBinarySchemaGen }}# schema_embed#{{ end }}#
 
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"
@@ -87,6 +91,15 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache
+      if: inputs.acceptance_fanout
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout == false
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
         cache-dependency-path: |
@@ -99,20 +112,30 @@ jobs:
       run: make prepare_local_workspace
       env:
         GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Generate schema-embed
+      if: inputs.acceptance_fanout
+      run: make schema_embed
+    - name: Build tfgen
+      if: inputs.acceptance_fanout
+      run: make tfgen_build_only
     - name: Generate schema
+      if: inputs.acceptance_fanout == false
       run: make schema
     - name: Build provider binary
+      if: inputs.acceptance_fanout == false
       run: make provider
     - name: Unit-test provider code
+      if: inputs.acceptance_fanout == false
       run: make test_provider
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OIDC_ROLE_ARN: ${{ steps.esc-secrets.outputs.OIDC_ROLE_ARN }}
     - name: Upload coverage reports to Codecov
+      if: inputs.acceptance_fanout == false
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       env:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
-    - if: inputs.is_pr
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
       name: Check Schema is Valid
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +146,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -39,6 +39,7 @@ jobs:
       default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
+      acceptance_fanout: true
 
   build_provider:
     uses: ./.github/workflows/build_provider.yml
@@ -56,6 +57,169 @@ jobs:
             {"os": "windows", "arch": "amd64"}
           ]
         }
+
+  test_provider:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      id-token: write # For ESC secrets.
+    steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Unit-test provider code
+      run: make test_provider
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OIDC_ROLE_ARN: ${{ steps.esc-secrets.outputs.OIDC_ROLE_ARN }}
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+
+  build_schema:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # For ESC secrets.
+    steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Cache examples generation
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Restore makefile progress
+      run: make --touch provider
+    - name: Generate schema
+      run: make schema
+      env:
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    - name: Check worktree clean
+      id: worktreeClean
+      uses: pulumi/git-status-check-action@v1
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
@@ -100,6 +264,8 @@ jobs:
     needs:
     - test
     - build_provider
+    - build_schema
+    - test_provider
     - license_check
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -296,7 +296,9 @@ tfgen_no_deps: .make/schema
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): provider/*.go provider/go.* .make/upstream
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+schema_embed:
+	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only schema_embed
 
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"
@@ -84,6 +88,15 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache
+      if: inputs.acceptance_fanout
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout == false
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
         cache-dependency-path: |
@@ -96,13 +109,23 @@ jobs:
       run: make prepare_local_workspace
       env:
         GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Generate schema-embed
+      if: inputs.acceptance_fanout
+      run: make schema_embed
+    - name: Build tfgen
+      if: inputs.acceptance_fanout
+      run: make tfgen_build_only
     - name: Generate schema
+      if: inputs.acceptance_fanout == false
       run: make schema
     - name: Build registry docs
+      if: inputs.acceptance_fanout == false
       run: make build_registry_docs
     - name: Build provider binary
+      if: inputs.acceptance_fanout == false
       run: make provider
     - name: Unit-test provider code
+      if: inputs.acceptance_fanout == false
       run: make test_provider
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ steps.esc-secrets.outputs.CLOUDFLARE_ACCOUNT_ID }}
@@ -110,10 +133,11 @@ jobs:
         CLOUDFLARE_ZONE_ID: ${{ steps.esc-secrets.outputs.CLOUDFLARE_ZONE_ID }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload coverage reports to Codecov
+      if: inputs.acceptance_fanout == false
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       env:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
-    - if: inputs.is_pr
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
       name: Check Schema is Valid
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +148,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -37,6 +37,7 @@ jobs:
       default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
+      acceptance_fanout: true
 
   build_provider:
     uses: ./.github/workflows/build_provider.yml
@@ -54,6 +55,171 @@ jobs:
             {"os": "windows", "arch": "amd64"}
           ]
         }
+
+  test_provider:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: pulumi-ubuntu-8core
+    needs: prerequisites
+    permissions:
+      contents: read
+      id-token: write # For ESC secrets.
+    steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Unit-test provider code
+      run: make test_provider
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ steps.esc-secrets.outputs.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ steps.esc-secrets.outputs.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ZONE_ID: ${{ steps.esc-secrets.outputs.CLOUDFLARE_ZONE_ID }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+
+  build_schema:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: pulumi-ubuntu-8core
+    needs: prerequisites
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # For ESC secrets.
+    steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        swap-storage: false
+        dotnet: false
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Cache examples generation
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Restore makefile progress
+      run: make --touch provider
+    - name: Generate schema
+      run: make schema
+      env:
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    - name: Build registry docs
+      run: make build_registry_docs
+    - name: Check worktree clean
+      id: worktreeClean
+      uses: pulumi/git-status-check-action@v1
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
@@ -104,6 +270,8 @@ jobs:
     needs:
     - test
     - build_provider
+    - build_schema
+    - test_provider
     - license_check
     - lint
     runs-on: pulumi-ubuntu-8core

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -302,7 +302,9 @@ tfgen_no_deps: .make/schema
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): provider/*.go provider/go.* .make/upstream
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+schema_embed:
+	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only schema_embed
 
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"
@@ -89,6 +93,15 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache
+      if: inputs.acceptance_fanout
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout == false
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
         cache-dependency-path: |
@@ -101,13 +114,23 @@ jobs:
       run: make prepare_local_workspace
       env:
         GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Generate schema-embed
+      if: inputs.acceptance_fanout
+      run: make schema_embed
+    - name: Build tfgen
+      if: inputs.acceptance_fanout
+      run: make tfgen_build_only
     - name: Generate schema
+      if: inputs.acceptance_fanout == false
       run: make schema
     - name: Build registry docs
+      if: inputs.acceptance_fanout == false
       run: make build_registry_docs
     - name: Build provider binary
+      if: inputs.acceptance_fanout == false
       run: make provider
     - name: Unit-test provider code
+      if: inputs.acceptance_fanout == false
       run: make test_provider
       env:
         ARM_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.ARM_CLIENT_SECRET }}
@@ -116,10 +139,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PRIVATE_SSH_KEY_FOR_DIGITALOCEAN: ${{ steps.esc-secrets.outputs.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Upload coverage reports to Codecov
+      if: inputs.acceptance_fanout == false
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       env:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
-    - if: inputs.is_pr
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
       name: Check Schema is Valid
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,7 +154,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -49,6 +49,7 @@ jobs:
       default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
+      acceptance_fanout: true
 
   build_provider:
     uses: ./.github/workflows/build_provider.yml
@@ -66,6 +67,158 @@ jobs:
             {"os": "windows", "arch": "amd64"}
           ]
         }
+
+  test_provider:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      id-token: write # For ESC secrets.
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Unit-test provider code
+      run: make test_provider
+      env:
+        ARM_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.ARM_CLIENT_SECRET }}
+        DIGITALOCEAN_TOKEN: ${{ steps.esc-secrets.outputs.DIGITALOCEAN_TOKEN }}
+        DOCKER_HUB_PASSWORD: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PRIVATE_SSH_KEY_FOR_DIGITALOCEAN: ${{ steps.esc-secrets.outputs.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+
+  build_schema:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # For ESC secrets.
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Cache examples generation
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Restore makefile progress
+      run: make --touch provider
+    - name: Generate schema
+      run: make schema
+      env:
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    - name: Build registry docs
+      run: make build_registry_docs
+    - name: Check worktree clean
+      id: worktreeClean
+      uses: pulumi/git-status-check-action@v1
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
@@ -116,6 +269,8 @@ jobs:
     needs:
     - test
     - build_provider
+    - build_schema
+    - test_provider
     - license_check
     - lint
     runs-on: ubuntu-latest

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -307,7 +307,9 @@ tfgen_no_deps: .make/schema
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): provider/*.go provider/go.* .make/upstream
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+schema_embed:
+	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only schema_embed
 
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"
@@ -86,6 +90,15 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache
+      if: inputs.acceptance_fanout
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout == false
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
         cache-dependency-path: |
@@ -107,11 +120,20 @@ jobs:
         role-duration-seconds: 7200
         role-session-name: aws@githubActions
         role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
+    - name: Generate schema-embed
+      if: inputs.acceptance_fanout
+      run: make schema_embed
+    - name: Build tfgen
+      if: inputs.acceptance_fanout
+      run: make tfgen_build_only
     - name: Generate schema
+      if: inputs.acceptance_fanout == false
       run: make schema
     - name: Build provider binary
+      if: inputs.acceptance_fanout == false
       run: make provider
     - name: Unit-test provider code
+      if: inputs.acceptance_fanout == false
       run: make test_provider
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,10 +146,11 @@ jobs:
         SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
     - name: Upload coverage reports to Codecov
+      if: inputs.acceptance_fanout == false
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       env:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
-    - if: inputs.is_pr
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
       name: Check Schema is Valid
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -138,7 +161,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -46,6 +46,7 @@ jobs:
       default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
+      acceptance_fanout: true
 
   build_provider:
     uses: ./.github/workflows/build_provider.yml
@@ -63,6 +64,160 @@ jobs:
             {"os": "windows", "arch": "amd64"}
           ]
         }
+
+  test_provider:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      id-token: write # For ESC secrets.
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Unit-test provider code
+      run: make test_provider
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+        PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
+        PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
+        PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
+        SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
+        SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
+        SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+
+  build_schema:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # For ESC secrets.
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Cache examples generation
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Restore makefile progress
+      run: make --touch provider
+    - name: Generate schema
+      run: make schema
+      env:
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    - name: Check worktree clean
+      id: worktreeClean
+      uses: pulumi/git-status-check-action@v1
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
@@ -113,6 +268,8 @@ jobs:
     needs:
     - test
     - build_provider
+    - build_schema
+    - test_provider
     - license_check
     - lint
     runs-on: ubuntu-latest

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -295,7 +295,9 @@ tfgen_no_deps: .make/schema
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): provider/*.go provider/go.* .make/upstream
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+schema_embed:
+	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only schema_embed
 
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -14,6 +14,10 @@ on:
       default_branch:
         type: string
         required: true
+      acceptance_fanout:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version:
         description: "Provider version being built"
@@ -79,6 +83,15 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: true
     - name: Setup Go Cache
+      if: inputs.acceptance_fanout
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Setup Go Cache
+      if: inputs.acceptance_fanout == false
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
         cache-dependency-path: |
@@ -91,19 +104,29 @@ jobs:
       run: make prepare_local_workspace
       env:
         GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Generate schema-embed
+      if: inputs.acceptance_fanout
+      run: make schema_embed
+    - name: Build tfgen
+      if: inputs.acceptance_fanout
+      run: make tfgen_build_only
     - name: Generate schema
+      if: inputs.acceptance_fanout == false
       run: make schema
     - name: Build provider binary
+      if: inputs.acceptance_fanout == false
       run: make provider
     - name: Unit-test provider code
+      if: inputs.acceptance_fanout == false
       run: make test_provider
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload coverage reports to Codecov
+      if: inputs.acceptance_fanout == false
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       env:
         CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
-    - if: inputs.is_pr
+    - if: inputs.acceptance_fanout == false && inputs.is_pr
       name: Check Schema is Valid
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -114,7 +137,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
+    - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -39,6 +39,7 @@ jobs:
       default_branch: ${{ github.event.pull_request.base.ref }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
+      acceptance_fanout: true
 
   build_provider:
     uses: ./.github/workflows/build_provider.yml
@@ -56,6 +57,152 @@ jobs:
             {"os": "windows", "arch": "amd64"}
           ]
         }
+
+  test_provider:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      id-token: write # For ESC secrets.
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Unit-test provider code
+      run: make test_provider
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+
+  build_schema:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # For ESC secrets.
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - env:
+        ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+        ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+        ESC_ACTION_OIDC_AUTH: "true"
+        ESC_ACTION_OIDC_ORGANIZATION: pulumi
+        ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      id: esc-secrets
+      name: Fetch secrets from ESC
+      uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+    - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      id: app-auth
+      with:
+        app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+        private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Cache examples generation
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          .pulumi/examples-cache
+        key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
+    - name: Setup mise
+      uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        github_token: ${{ steps.app-auth.outputs.token }}
+        cache_save: false
+    - name: Restore Go Cache
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
+      env:
+        GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+    - name: Restore prerequisites
+      uses: ./.github/actions/download-prerequisites
+    - name: Restore makefile progress
+      run: make --touch provider
+    - name: Generate schema
+      run: make schema
+      env:
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    - name: Check worktree clean
+      id: worktreeClean
+      uses: pulumi/git-status-check-action@v1
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "SCHEMA_CHANGES<<$EOF";
+          schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json;
+          echo "$EOF";
+        } >> "$GITHUB_ENV"
+    - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      name: Comment on PR with Details of Schema Check
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-tag: schemaCheck
+        message: >+
+          ${{ env.SCHEMA_CHANGES }}
+
+
+          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
@@ -106,6 +253,8 @@ jobs:
     needs:
     - test
     - build_provider
+    - build_schema
+    - test_provider
     - license_check
     - lint
     runs-on: ubuntu-latest

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -295,7 +295,9 @@ tfgen_no_deps: .make/schema
 tfgen_build_only: bin/$(CODEGEN)
 bin/$(CODEGEN): provider/*.go provider/go.* .make/upstream
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(CODEGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(CODEGEN))
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+schema_embed:
+	(cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go)
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only schema_embed
 
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream


### PR DESCRIPTION
## Summary

- split traditional bridged-provider acceptance prerequisites into a lightweight prerequisite phase plus separate `test_provider` and `build_schema` jobs
- allow provider and SDK builds, and then examples, to start without waiting on provider unit tests or schema comparison
- keep the old prerequisite ordering for `NoSchema`, `UseProviderBinarySchemaGen`, and non-acceptance workflow callers

## Motivation

`pulumi/pulumi-aws` has been spending too much wall-clock time in `run-acceptance-tests` because the `prerequisites` job serializes work that does not need to block provider builds, SDK builds, or example tests.

We prototyped this ordering change directly in `pulumi-aws` before moving it into `ci-mgmt`. In that experiment, the improvement came from workflow ordering rather than dropping validation. The old critical path was roughly 1h50m+, while the refactored ordering finished closer to 1h00m. The key behavioral change was that examples could start once provider and SDK artifacts were ready, instead of waiting for `test_provider`.

This PR brings that ordering into generated bridged-provider acceptance workflows while keeping the scope conservative. Only traditional schema-based acceptance workflows opt into the split. Release, prerelease, main, and nightly workflows continue to use the full existing `prerequisites` behavior unless they explicitly opt into the fan-out path later.

## Details

- adds an `acceptance_fanout` input to `prerequisites.yml`, defaulting to `false`
- when fan-out is enabled, prerequisites only prepares the workspace, generates `schema_embed`, builds `tfgen`, and uploads prerequisite artifacts
- adds separate `test_provider` and `build_schema` jobs to `run-acceptance-tests.yml`
- updates sentinel dependencies so `test` does not need `test_provider`, while sentinel still depends on `test`, `build_provider`, `build_schema`, `test_provider`, and `license_check`
- adds a generated `schema_embed` Makefile target for traditional bridged providers
- preserves the old ordering for `NoSchema` and `UseProviderBinarySchemaGen`

## Testing

- `cd provider-ci && make gen`
- `git diff --check`
- `cd provider-ci && make all`