### PR TITLE
Fail crossbuild loudly when Windows signing silently skips

### DIFF
--- a/provider-ci/internal/pkg/templates/base/scripts/crossbuild.mk
+++ b/provider-ci/internal/pkg/templates/base/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/internal/pkg/templates/base/scripts/verify_signed.py
+++ b/provider-ci/internal/pkg/templates/base/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/aws/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/aws/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/aws/scripts/verify_signed.py
+++ b/provider-ci/test-providers/aws/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/cloudflare/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/cloudflare/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/cloudflare/scripts/verify_signed.py
+++ b/provider-ci/test-providers/cloudflare/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/docker/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/docker/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/docker/scripts/verify_signed.py
+++ b/provider-ci/test-providers/docker/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/eks/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/eks/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/eks/scripts/verify_signed.py
+++ b/provider-ci/test-providers/eks/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/pulumiservice/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/pulumiservice/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/pulumiservice/scripts/verify_signed.py
+++ b/provider-ci/test-providers/pulumiservice/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/terraform-module/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/terraform-module/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/terraform-module/scripts/verify_signed.py
+++ b/provider-ci/test-providers/terraform-module/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/provider-ci/test-providers/xyz/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/xyz/scripts/crossbuild.mk
@@ -59,6 +59,12 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 		fi; \
 	fi
 
+	@# Verify the windows binary was actually signed when signing was expected.
+	@# This runs in its own shell as a separate recipe line, so make checks its
+	@# exit code directly (no set-e-inside-if antipattern). Catches the silent
+	@# failure where the signing block above exits 0 without producing a signature.
+	@[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || python3 scripts/verify_signed.py "$@"
+
 bin/jsign-7.4.jar:
 	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 

--- a/provider-ci/test-providers/xyz/scripts/verify_signed.py
+++ b/provider-ci/test-providers/xyz/scripts/verify_signed.py
@@ -1,0 +1,51 @@
+"""Verify a Windows PE binary has an Authenticode signature attached.
+
+Presence check only: parses the PE Optional Header's Certificate Table
+directory entry and exits 0 if it is non-empty, non-zero otherwise. Does
+not validate the certificate chain or the signature itself; full chain
+validation is the verify-release workflow's job.
+
+Purpose: catch the silent-failure pattern in scripts/crossbuild.mk where
+the signing block exits 0 without producing a signature (e.g. a future
+regression that returns the recipe to /bin/sh and silently skips the
+bash conditional).
+
+Usage: python3 scripts/verify_signed.py <path-to-exe>
+"""
+
+import struct
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <path-to-exe>",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # PE header offset is stored at 0x3C.
+    pe = struct.unpack_from("<I", data, 0x3C)[0]
+    # Optional header Magic: 0x10B = PE32, 0x20B = PE32+.
+    magic = struct.unpack_from("<H", data, pe + 24)[0]
+    # DataDirectory starts at +96 (PE32) or +112 (PE32+) of optional header.
+    # Certificate Table is index 4; each entry is 8 bytes (VirtualAddress, Size).
+    dd_start = pe + 24 + (96 if magic == 0x10B else 112)
+    cert_size = struct.unpack_from("<I", data, dd_start + 4 * 8 + 4)[0]
+
+    if cert_size == 0:
+        print(
+            f"ERROR: {path} has no Authenticode signature attached. "
+            "The signing step in crossbuild.mk silently failed.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

- The Windows signing block in `scripts/crossbuild.mk` wraps the bash conditional in `@set -e; if [[ ... ]]; then ...; fi`. POSIX `set -e` is suppressed inside `if` condition lists, so if `[[` ever fails (e.g. the recipe falls back to `/bin/sh` on a host where `/bin/sh` is dash) the condition silently returns false, the then-block is skipped, and the recipe exits 0 with an unsigned binary. CI stays green.
- Add `scripts/verify_signed.py`, a small presence check that parses the PE Optional Header's Certificate Table directory entry and exits non-zero if it is empty.
- Wire it into the `bin/%/$(PROVIDER).exe` recipe as **its own recipe line** (no `if` wrapping), guarded so it only runs when signing was expected:

  ```makefile
  @[ "${GOOS}" != "windows" ] || [ "${SKIP_SIGNING}" = "true" ] || \
      python3 scripts/verify_signed.py "$@"
  ```

Because the verify is its own recipe line, make checks its exit code directly and fails the recipe on a missing signature. The `set -e`-inside-`if` antipattern can no longer hide a silently-skipped signing step.

## Test plan

- [x] `cd provider-ci && make all` passes locally (Go unit tests, actionlint on regenerated test-providers).
- [x] `verify_signed.py` validated against a known-signed `.exe` (exit 0) and a known-unsigned `.exe` (exit 1 with the documented error).
- [ ] Reviewer: confirm regenerated test-providers diff matches the template change. Each bridged test-provider should pick up the new `scripts/verify_signed.py` and the new recipe line.

## Notes

Opened as **draft** for initial review. PR-field checklist (assignee, reviewers, milestone, project) will be filled once the diff is acked.

Part of pulumi/home#4655, pulumi/home#4656, pulumi/home#4657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)