### PR TITLE
Use canonical SHELL + .SHELLFLAGS instead of the shorthand

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -1,4 +1,5 @@
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 NAME ?= all
 PROVIDERS := $(patsubst %/, %, $(wildcard providers/*/))
 PROVIDER_REPOS := $(addsuffix /repo, $(PROVIDERS))

--- a/provider-ci/internal/pkg/templates/base/scripts/crossbuild.mk
+++ b/provider-ci/internal/pkg/templates/base/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/aws/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/aws/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/cloudflare/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/cloudflare/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/docker/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/docker/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/eks/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/eks/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/pulumiservice/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/pulumiservice/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/terraform-module/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/terraform-module/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=

--- a/provider-ci/test-providers/xyz/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/xyz/scripts/crossbuild.mk
@@ -1,6 +1,7 @@
 # Provider cross-platform build & packaging
 
-SHELL := /bin/bash -o pipefail
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
 
 # Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=


### PR DESCRIPTION
## Summary

- `SHELL := /bin/bash -o pipefail` happens to work in practice because GNU Make splits the `SHELL` variable on whitespace when invoking, but per the [GNU Make documentation](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html) the canonical form is `SHELL := /bin/bash` combined with the shell flags in `.SHELLFLAGS`.
- Switch the two sites under ci-mgmt's control (the meta-Makefile and the bridged `crossbuild.mk` template) to:

  ```makefile
  SHELL := /bin/bash
  .SHELLFLAGS := -eo pipefail -c
  ```

- The extra `-e` makes every recipe invocation exit on first error by default. Recipes that already set `set -e` themselves are unaffected; recipes relying on commands continuing past a failure now have to opt in explicitly with `cmd || true`.

## Test plan

- [x] `cd provider-ci && make all` passes locally (Go unit tests, actionlint on regenerated test-providers, no unrelated diffs).
- [ ] Reviewer: confirm regenerated test-providers `scripts/crossbuild.mk` diffs match the template change (`SHELL` + `.SHELLFLAGS` swap, nothing else).

## Notes

Opened as **draft** for initial review. PR-field checklist (assignee, reviewers, milestone, project) will be filled once the diff is acked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)