### PR TITLE
Converge pulumi-aws-native onto standard native release pattern

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -446,7 +446,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: #{{ if .Config.Runner.Publish }}##{{ .Config.Runner.Publish }}##{{ else if eq .Config.Provider "aws-native" }}#macos-latest#{{ else }}#ubuntu-latest#{{ end }}#
+    runs-on: #{{ if .Config.Runner.Publish }}##{{ .Config.Runner.Publish }}##{{ else }}#ubuntu-latest#{{ end }}#
     needs: test
     name: publish
     permissions:
@@ -477,7 +477,6 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-    #{{- if ne .Config.Provider "aws-native" }}#
     - name: Clear GitHub Actions Ubuntu runner disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
@@ -487,7 +486,6 @@ jobs:
         haskell: true
         swap-storage: true
         large-packages: false
-    #{{- end }}#
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -406,7 +406,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: #{{ if .Config.Runner.Publish }}##{{ .Config.Runner.Publish }}##{{ else if eq .Config.Provider "aws-native" }}#macos-latest#{{ else }}#ubuntu-latest#{{ end }}#
+    runs-on: #{{ if .Config.Runner.Publish }}##{{ .Config.Runner.Publish }}##{{ else }}#ubuntu-latest#{{ end }}#
     needs: test
     name: publish
     permissions:
@@ -437,7 +437,6 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-    #{{- if ne .Config.Provider "aws-native" }}#
     - name: Clear GitHub Actions Ubuntu runner disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
@@ -447,7 +446,6 @@ jobs:
         haskell: true
         swap-storage: true
         large-packages: false
-    #{{- end }}#
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -408,7 +408,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: #{{ if .Config.Runner.Publish }}##{{ .Config.Runner.Publish }}##{{ else if eq .Config.Provider "aws-native" }}#macos-latest#{{ else }}#ubuntu-latest#{{ end }}#
+    runs-on: #{{ if .Config.Runner.Publish }}##{{ .Config.Runner.Publish }}##{{ else }}#ubuntu-latest#{{ end }}#
     needs: test
     name: publish
     permissions:
@@ -439,7 +439,6 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
-    #{{- if ne .Config.Provider "aws-native" }}#
     - name: Clear GitHub Actions Ubuntu runner disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
@@ -449,7 +448,6 @@ jobs:
         haskell: true
         swap-storage: true
         large-packages: false
-    #{{- end }}#
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:

--- a/provider-ci/internal/pkg/templates/native/.goreleaser.prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.goreleaser.prerelease.yml
@@ -20,29 +20,6 @@ before:
   - make generate_schema
 #{{- end }}#
 builds:
-#{{- if eq .Config.Provider "aws-native" }}#
-- dir: provider
-  env:
-  - GO111MODULE=on
-  goos:
-  - darwin
-  - windows
-  - linux
-  goarch:
-  - amd64
-  - arm64
-  ignore: []
-  main: ./cmd/pulumi-resource-#{{ .Config.Provider }}#/
-  ldflags:
-  - -s
-  - -w
-#{{- if ge .Config.MajorVersion 2 }}#
-  - -X github.com/pulumi/pulumi-#{{ .Config.Provider }}#/provider/v#{{ .Config.MajorVersion }}#/pkg/version.Version={{.Tag}}
-#{{- else }}#
-  - -X github.com/pulumi/pulumi-#{{ .Config.Provider }}#/provider/pkg/version.Version={{.Tag}}
-#{{- end }}#
-  binary: pulumi-resource-#{{ .Config.Provider }}#
-#{{- else }}#
 - id: build-provider
 #{{- if ne .Config.Provider "terraform" }}#
   dir: provider
@@ -100,7 +77,6 @@ builds:
   hooks:
     post:
     - make sign-goreleaser-exe-{{ .Arch }}
-#{{- end }}#
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive

--- a/provider-ci/internal/pkg/templates/native/.goreleaser.yml
+++ b/provider-ci/internal/pkg/templates/native/.goreleaser.yml
@@ -19,29 +19,6 @@ before:
   - make generate_schema
 #{{- end }}#
 builds:
-#{{- if eq .Config.Provider "aws-native" }}#
-- dir: provider
-  env:
-  - GO111MODULE=on
-  goos:
-  - darwin
-  - windows
-  - linux
-  goarch:
-  - amd64
-  - arm64
-  ignore: []
-  main: ./cmd/pulumi-resource-#{{ .Config.Provider }}#/
-  ldflags:
-  - -s
-  - -w
-#{{- if ge .Config.MajorVersion 2 }}#
-  - -X github.com/pulumi/pulumi-#{{ .Config.Provider }}#/provider/v#{{ .Config.MajorVersion }}#/pkg/version.Version={{.Tag}}
-#{{- else }}#
-  - -X github.com/pulumi/pulumi-#{{ .Config.Provider }}#/provider/pkg/version.Version={{.Tag}}
-#{{- end }}#
-  binary: pulumi-resource-#{{ .Config.Provider }}#
-#{{- else }}#
 - id: build-provider
 #{{- if ne .Config.Provider "terraform" }}#
   dir: provider
@@ -99,7 +76,6 @@ builds:
   hooks:
     post:
     - make sign-goreleaser-exe-{{ .Arch }}
-#{{- end }}#
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -383,7 +383,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: test
     name: publish
     permissions:
@@ -420,6 +420,15 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         github_token: ${{ steps.app-auth.outputs.token }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -339,7 +339,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: test
     name: publish
     permissions:
@@ -376,6 +376,15 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         github_token: ${{ steps.app-auth.outputs.token }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: test
     name: publish
     permissions:
@@ -376,6 +376,15 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         github_token: ${{ steps.app-auth.outputs.token }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:

--- a/provider-ci/test-providers/aws-native/.goreleaser.prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.goreleaser.prerelease.yml
@@ -7,23 +7,42 @@ before:
   - make codegen
   - make generate_schema
 builds:
-- dir: provider
+- id: build-provider
+  dir: provider
   env:
+  - CGO_ENABLED=0
   - GO111MODULE=on
   goos:
   - darwin
-  - windows
   - linux
   goarch:
   - amd64
   - arm64
-  ignore: []
+  ignore: &a1 []
   main: ./cmd/pulumi-resource-aws-native/
-  ldflags:
-  - -s
-  - -w
-  - -X github.com/pulumi/pulumi-aws-native/provider/pkg/version.Version={{.Tag}}
+  ldflags: &a2
+    - -s
+    - -w
+    - -X
+      github.com/pulumi/pulumi-aws-native/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-aws-native
+- id: build-provider-sign-windows
+  dir: provider
+  env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  goos:
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ignore: *a1
+  main: ./cmd/pulumi-resource-aws-native/
+  ldflags: *a2
+  binary: pulumi-resource-aws-native
+  hooks:
+    post:
+    - make sign-goreleaser-exe-{{ .Arch }}
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive

--- a/provider-ci/test-providers/aws-native/.goreleaser.yml
+++ b/provider-ci/test-providers/aws-native/.goreleaser.yml
@@ -6,23 +6,42 @@ before:
   - make codegen
   - make generate_schema
 builds:
-- dir: provider
+- id: build-provider
+  dir: provider
   env:
+  - CGO_ENABLED=0
   - GO111MODULE=on
   goos:
   - darwin
-  - windows
   - linux
   goarch:
   - amd64
   - arm64
-  ignore: []
+  ignore: &a1 []
   main: ./cmd/pulumi-resource-aws-native/
-  ldflags:
-  - -s
-  - -w
-  - -X github.com/pulumi/pulumi-aws-native/provider/pkg/version.Version={{.Tag}}
+  ldflags: &a2
+    - -s
+    - -w
+    - -X
+      github.com/pulumi/pulumi-aws-native/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-aws-native
+- id: build-provider-sign-windows
+  dir: provider
+  env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  goos:
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ignore: *a1
+  main: ./cmd/pulumi-resource-aws-native/
+  ldflags: *a2
+  binary: pulumi-resource-aws-native
+  hooks:
+    post:
+    - make sign-goreleaser-exe-{{ .Arch }}
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive


### PR DESCRIPTION
## Summary

The native goreleaser template special-cases `aws-native` into a single all-OSes build entry with no windows signing post-hook, while every other native provider gets the standard split build (`build-provider` for darwin/linux + `build-provider-sign-windows` for windows with `make sign-goreleaser-exe-{{ .Arch }}`). Independently, aws-native's publish job runs on `macos-latest`, which has no preinstalled `az` CLI that the signing target relies on.

Drop both carve-outs so aws-native flows through the same goreleaser layout and `ubuntu-latest` publish runner as the rest of the native template. The disk-cleanup step that was conditionally skipped for aws-native re-enables for the same reason.

Result: aws-native windows binaries get signed via the same path as pulumi-command/pulumi-kubernetes/etc.

Verified locally: `cd provider-ci && make all` passes, the only files that change are the five edited templates and their five regenerated `test-providers/aws-native/` outputs, and the regenerated artifacts contain the expected `build-provider` + `build-provider-sign-windows` (with signing hook) pair plus the `ubuntu-latest` publish runner with the disk-cleanup step.

## Why this is safe

- The provider's Makefile already defines `sign-goreleaser-exe-amd64|arm64` with hardcoded `dist/build-provider-sign-windows_windows_\${GORELEASER_ARCH}/...` paths, so it already expects the standard split-build layout. No provider-side change is required.
- The publish job is a thin pipeline (ESC secrets → version → setup-tools → AWS creds → goreleaser → Slack on failure). GoReleaser cross-compiles darwin/linux/windows from any host, so nothing in the job intrinsically needs macOS. The `macos-latest` choice predates ci-mgmt's native template (carried over from the old `native-provider-ci` config in 2020) and has no recorded rationale.
- The `runs-on` line still honours `.Config.Runner.Publish` for any provider that needs to override per-provider.
- aws-native's signing-unrelated carve-outs are preserved: the `before:` hooks (`init_submodules`, `codegen`, `generate_schema`) and the AWS-credentials export step the test job needs.

Part of pulumi/home#4655

## Dry-run verification on real `pulumi/aws-native`

Dispatched `update-workflows-single-bridged-provider.yml` from this PR branch against `pulumi/aws-native` (run [27757439528](https://github.com/pulumi/ci-mgmt/actions/runs/27757439528), `automerge=false`). It completed successfully and opened [pulumi/pulumi-aws-native#3044](https://github.com/pulumi/pulumi-aws-native/pull/3044). The five regenerated files there (`build.yml`, `prerelease.yml`, `release.yml`, `.goreleaser.yml`, `.goreleaser.prerelease.yml`) are byte-identical to the `test-providers/aws-native/` outputs in this PR: `macos-latest` → `ubuntu-latest` on the publish job, the disk-cleanup step re-enabled, and the `build-provider` + `build-provider-sign-windows` split with the `make sign-goreleaser-exe-{{ .Arch }}` signing hook. #3044 is a verification artifact, not for merge.
