### PR TITLE
Fix always-false condition on cluster teardown step

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -678,7 +678,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'pulumi' }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -678,7 +678,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -722,7 +722,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'pulumi' }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -722,7 +722,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -756,7 +756,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'pulumi' }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -756,7 +756,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -625,7 +625,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'pulumi' }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -625,7 +625,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -669,7 +669,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'pulumi' }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -669,7 +669,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -705,7 +705,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'pulumi' }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -705,7 +705,7 @@ jobs:
     needs:
     - build-test-cluster
     - test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() }}
     permissions:
       contents: read
       id-token: write # For Pulumi access token OIDC.


### PR DESCRIPTION
We should always run the cluster teardown step. The old code was incorrectly gating it on a pull request ref, which _never_ exists on a `main` or `publish` workflow. There's the possibility for extra noise if the cluster _setup_ failed but it would be fairly obvious in context, so "always" is the defensible condition.

This will address the part of https://github.com/pulumi/pulumi-kubernetes/issues/4329 where we kept leaking clusters into our GCP project and relied on the internal cleanup sweep.

- **bugfix: Remove always-false condition on cluster cleanup step and just always run**
- **Regenerate test providers**
