### PR TITLE
Pass app token to gh-aw steps in upgrade-agentic-workflows

### DIFF
--- a/.github/workflows/upgrade-agentic-workflows.yml
+++ b/.github/workflows/upgrade-agentic-workflows.yml
@@ -39,8 +39,12 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
       - name: Update root agentic workflows from sources
         run: gh-aw update --force
+        env:
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}
       - name: Upgrade root agentic workflow tooling
         run: gh-aw upgrade --approve
+        env:
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}
       - name: Remove unused gh-aw generated files
         run: |
           rm -rf .github/agents


### PR DESCRIPTION
## Summary

The `Upgrade Agentic Workflows` job has two steps that run `gh-aw` (`Update root agentic workflows from sources` and `Upgrade root agentic workflow tooling`). `gh-aw` shells out to the `gh` CLI to resolve refs and the default branch of the private workflow-source repos. Those two steps had no `GH_TOKEN` in their environment, so every `gh` call exited with `status 4` (`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable`) and the job ended with `no workflows were successfully updated`.

We already mint an app token via `actions/create-github-app-token` (`steps.app-auth`) and pass it to `checkout`, `mise`, and the create-PR step. This wires the same token into the two `gh-aw` steps as `GH_TOKEN` so their `gh` calls authenticate against the private sources. Job-level `env` cannot reference `steps.*`, so the token is set per step. The sync, cleanup, and verify steps do not invoke `gh` and are left unchanged.

Part of pulumi/ci-mgmt#2241

## Test plan

- [ ] Next scheduled run of `Upgrade Agentic Workflows` (or a manual `workflow_dispatch`) gets past the `Update root agentic workflows from sources` step instead of failing with `gh: ... set the GH_TOKEN environment variable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
