### PR TITLE
Trace build_provider_cmd phases in bridged Makefile template

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -312,15 +312,16 @@ lint.fix: upstream
 .PHONY: lint lint.fix
 
 #{{- if .Config.BuildProviderCmd }}#
-build_provider_cmd = #{{ if .Config.BuildProviderPre -}}#
-                         #{{ .Config.BuildProviderPre }}#;
-                     #{{- end -}}#
-                     #{{ .Config.BuildProviderCmd }}#
+build_provider_cmd = set -x; \
+#{{ if .Config.BuildProviderPre }}##{{ .Config.BuildProviderPre }}#; \
+#{{ end -}}#
+#{{ .Config.BuildProviderCmd }}#
 #{{- else }}#
-build_provider_cmd = #{{ if .Config.BuildProviderPre -}}#
-                         #{{ .Config.BuildProviderPre }}#;
-                     #{{- end -}}#
-                     cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = set -x; \
+#{{ if .Config.BuildProviderPre }}##{{ .Config.BuildProviderPre }}#; \
+#{{ end -}}#
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
+cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 #{{- end }}#
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -231,7 +231,10 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh;cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = set -x; \
+VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh; \
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
+cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -238,7 +238,9 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = set -x; \
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
+cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -243,7 +243,9 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = set -x; \
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
+cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -232,7 +232,8 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = OS=$(1) ARCH=$(2) OUT=$(3) yarn --cwd nodejs/eks build
+build_provider_cmd = set -x; \
+OS=$(1) ARCH=$(2) OUT=$(3) yarn --cwd nodejs/eks build
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -231,7 +231,8 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = OS=$(1) ARCH=$(2) OUT=$(3) go build .
+build_provider_cmd = set -x; \
+OS=$(1) ARCH=$(2) OUT=$(3) go build .
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -231,7 +231,9 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = set -x; \
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
+cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 


### PR DESCRIPTION
## Summary

`build_provider_cmd` rendered as a single opaque `;`-chained shell command, so a provider build logged one undifferentiated span with no signal for where time went across schema generation, module download, compilation, and linking.

This makes each phase observable in the job log:

- `set -x` is prepended in **both** template branches, so every chained sub-command is traced with a timestamp. Language-agnostic; this is the only change non-Go `buildProviderCmd` overrides (e.g. `eks`, `pulumiservice`) receive.
- The **default branch** splits `go mod download` into its own statement and adds `-v` to `go build`, so the module-fetch phase is distinct and per-package compilation is observable.

The rendered value still collapses to a single `sh -c` invocation with the same `;`/`&&` joins as before — cosmetic multi-line via backslash continuations only. Error semantics are preserved: the final command still determines the recipe exit status, exactly as the previous single-line form (verified with `make -n`).

Scope is the `base` Makefile template plus the six bridged provider Makefiles that consume it (aws, cloudflare, docker, eks, pulumiservice, xyz). No native providers, workflows, or `.ci-mgmt.yaml` touched. `make all` passes locally: build, Go tests, deterministic regeneration of all 15 test providers, and actionlint.

## What this enables

The downstream goal is to turn that opaque build span into a readable phase breakdown:

<img width="1960" height="832" alt="build-provider-breakdown" src="https://github.com/user-attachments/assets/b9529555-3808-4be1-8b64-7734d9a1d29a" />

Part of #2218