### PR TITLE
Fix duplicate cd provider in build_provider_cmd

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -320,8 +320,8 @@ build_provider_cmd = set -x; \
 build_provider_cmd = set -x; \
 #{{ if .Config.BuildProviderPre }}##{{ .Config.BuildProviderPre }}#; \
 #{{ end -}}#
-cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
-cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download && \
+GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 #{{- end }}#
 
 provider: bin/$(PROVIDER)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -233,8 +233,8 @@ lint.fix: upstream
 .PHONY: lint lint.fix
 build_provider_cmd = set -x; \
 VERSION=${VERSION_GENERIC} ./scripts/minimal_schema.sh; \
-cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
-cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download && \
+GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -239,8 +239,8 @@ lint.fix: upstream
 
 .PHONY: lint lint.fix
 build_provider_cmd = set -x; \
-cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
-cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download && \
+GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -244,8 +244,8 @@ lint.fix: upstream
 
 .PHONY: lint lint.fix
 build_provider_cmd = set -x; \
-cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
-cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download && \
+GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -232,8 +232,8 @@ lint.fix: upstream
 
 .PHONY: lint lint.fix
 build_provider_cmd = set -x; \
-cd provider && GOOS=$(1) GOARCH=$(2) go mod download; \
-cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+cd provider && GOOS=$(1) GOARCH=$(2) go mod download && \
+GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 


### PR DESCRIPTION
## Summary

The phase split in #2244 emitted two `cd provider` statements within `build_provider_cmd`. Because the whole value collapses to a single `sh -c`, the second `cd provider` is relative to the already-changed `provider/` directory, fails with `No such file or directory`, and `&&` aborts the recipe before `go build` runs (`make: *** Error 1`).

Fix: collapse to a **single** `cd provider` with an `&&` chain — `cd provider && go mod download && go build …`. One directory change, no leaked `cd`. `set -x` still emits distinct `+ go mod download` / `+ go build` traces, so the per-phase log-timing objective from #2244 is preserved. The `buildProviderCmd` override branch (non-Go providers) is unaffected.

Scope: the `base` Makefile template plus the four default-branch bridged test providers (aws, cloudflare, docker, xyz); eks/pulumiservice (override branch) are correctly untouched. `make gen` regenerates deterministically; `make -n` confirms the collapsed recipe contains exactly one `cd provider`.

## Verification

Validated against a real pulumi-aws build: a single-provider rollout built from this branch regenerates pulumi-aws with the corrected `build_provider_cmd` — https://github.com/pulumi/ci-mgmt/actions/runs/26042269844 . The resulting pulumi-aws PR's `prerequisites / Build provider binary` step exercises the single-`cd` path end to end.

Part of #2218
