### PR TITLE
Add KinD prerequisites step for pulumi-kubernetes

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -504,6 +504,9 @@ jobs:
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
         node_image: kindest/node:v1.29.2
+        config: scripts/kind-config.yaml
+    - name: Install KinD prerequisites (Calico + MetalLB + Traefik)
+      run: ./scripts/setup-kind-cluster.sh
     #{{- else if eq .Config.Provider "kubernetes-cert-manager" }}#
     - name: Setup KinD cluster
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -479,6 +479,9 @@ jobs:
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
         node_image: kindest/node:v1.29.2
+        config: scripts/kind-config.yaml
+    - name: Install KinD prerequisites (Calico + MetalLB + Traefik)
+      run: ./scripts/setup-kind-cluster.sh
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
         2h -parallel 4 -short ./...


### PR DESCRIPTION
Wires [pulumi/pulumi-kubernetes#4368](https://github.com/pulumi/pulumi-kubernetes/pull/4368) into the native `run-acceptance-tests` template.

Three-line diff in the kubernetes-provider block only:
- `config: scripts/kind-config.yaml` on `helm/kind-action` (disables kindnet so Calico can replace it).
- New step `./scripts/setup-kind-cluster.sh` to install Calico + MetalLB + Traefik.

Step 1 of [pulumi/pulumi-kubernetes#4356](https://github.com/pulumi/pulumi-kubernetes/issues/4356). Both this and pulumi-kubernetes#4368 need to land before the workflow regen picks them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)