### PR TITLE
Pass GITHUB_TOKEN to the KinD prerequisites step

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -507,6 +507,8 @@ jobs:
         config: scripts/kind-config.yaml
     - name: Install KinD prerequisites (Calico + MetalLB + Traefik)
       run: ./scripts/setup-kind-cluster.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     #{{- else if eq .Config.Provider "kubernetes-cert-manager" }}#
     - name: Setup KinD cluster
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -482,6 +482,8 @@ jobs:
         config: scripts/kind-config.yaml
     - name: Install KinD prerequisites (Calico + MetalLB + Traefik)
       run: ./scripts/setup-kind-cluster.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
         2h -parallel 4 -short ./...


### PR DESCRIPTION
## Summary
The KinD prerequisites step from #2249 runs `setup-kind-cluster.sh`, which uses `gh` to fetch the Calico and MetalLB manifests. `gh` exits non-zero in GitHub Actions without a token, so the step fails immediately. Pass `GITHUB_TOKEN`, matching the adjacent "Run tests" step.

Surfaced by pulumi/pulumi-kubernetes#4372 (all `test` jobs failed at this step).

## Test plan
- [ ] `test-providers/kubernetes` fixture regenerated; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)