### PR TITLE
Document the regen-safe .mk prerequisite hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ Steps:
   - NEVER create provider-specific template directory
   - Look for other ways the provider can extend behavior (in the provider's repo, not ci-mgmt):
      - Custom tools specified in mise.toml.
-     - TODO: Custom Makefile target behavior overriding defaults.
+     - Extra prerequisites for a generated Makefile target (e.g. `bin/$(PROVIDER)`) via a recipe-less rule in a `.mk/*.mk` include. The generated Makefile picks these up through `include $(wildcard .mk/*.mk)`; see the comment above that line in `templates/base/Makefile`. Add prerequisites only, a recipe would override the generated target and warn.
 
 **Remember**: Workflow files use `#{{ }}#` delimiters for templates, but GitHub Actions expressions still use `${{ }}`
 

--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -458,6 +458,11 @@ renovate:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -329,6 +329,11 @@ debug_tfgen:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -331,6 +331,11 @@ debug_tfgen:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -336,6 +336,11 @@ debug_tfgen:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -328,6 +328,11 @@ renovate:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -317,6 +317,11 @@ debug_tfgen:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -324,6 +324,11 @@ debug_tfgen:
 include scripts/crossbuild.mk
 
 # Permit providers to extend the Makefile with provider-specific Make includes.
+# A *.mk file here may add prerequisites to a generated target using a rule with
+# NO recipe, e.g. to rebuild bin/$(PROVIDER) when embedded data files change:
+#     bin/$(PROVIDER): provider/pkg/cloud/spec.json
+# Add prerequisites only; giving a generated target a recipe here overrides the
+# generated one and triggers make's "overriding commands" warning.
 include $(wildcard .mk/*.mk)
 
 # Optional, provider-owned SDK codegen hooks. When a `sdk-hooks.mk` exists in


### PR DESCRIPTION
## Summary

The generated provider Makefile already ends with `include $(wildcard .mk/*.mk)`, which lets a provider extend it from files under `.mk/` without forking. This documents one specific, supported use of that hook: adding extra prerequisites to a generated target (notably `bin/$(PROVIDER)`) from a recipe-less rule in a `.mk/*.mk` file, so a provider can declare inputs that are embedded into the binary and keep incremental rebuilds correct without editing the generated Makefile.

Changes:
- Expand the comment above `include $(wildcard .mk/*.mk)` in `templates/base/Makefile` to describe the prerequisite-only contract, with an example and the "add prerequisites only, never a recipe" caveat (a recipe would override the generated target and trigger make's `overriding commands` warning).
- Replace the stale `TODO: Custom Makefile target behavior overriding defaults.` in `AGENTS.md` (and `CLAUDE.md` via the symlink) with a pointer to that mechanism.
- Regenerate the test providers so the committed Makefiles carry the new comment.

No template logic or config changes; the hook itself already existed. The first consumer is pulumi/pulumi-pulumiservice#885, which moves its previously-inline (and regen-clobbered) `bin/$(PROVIDER)` prerequisites into `.mk/provider-build.mk`.

Verified with `make gen`: the diff is comment-only across the six base-Makefile test providers, deterministic, and `actionlint` passes for every provider.

Part of pulumi/ci-mgmt#2285.
