### PR TITLE
Add `make compare_sdk_<lang>` target to the bridged Makefile template

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -132,6 +132,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] =#{{ range .Config.Languages }}# #{{ . }}##{{ end }}#"
 	@echo ""
@@ -276,6 +277,27 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+#{{- if not .Config.NoSchema }}#
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks:#{{ range .Config.Languages }}# compare_sdk_#{{ . }}##{{ end }}#
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
+#{{- end }}#
 
 #{{- if .Config.RegistryDocs }}#
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] = nodejs python dotnet go java"
 	@echo ""
@@ -205,6 +206,24 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] = nodejs python dotnet go java"
 	@echo ""
@@ -205,6 +206,24 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
 build_registry_docs: .make/build_registry_docs
 .make/build_registry_docs: .make/mise_install bin/$(CODEGEN)

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] = nodejs python dotnet go java"
 	@echo ""
@@ -205,6 +206,24 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
 build_registry_docs: .make/build_registry_docs
 .make/build_registry_docs: .make/mise_install bin/$(CODEGEN)

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] = nodejs python dotnet go java"
 	@echo ""
@@ -206,6 +207,24 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] = nodejs python dotnet go java"
 	@echo ""
@@ -205,6 +206,24 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  generate_[language]    Generate the SDK files ready for committing"
 	@echo "  build_[language]       Build the SDK to check correctness"
 	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo "  compare_sdk_[language] Compare legacy vs gen-sdk SDK output (shadow-gen diff)"
 	@echo ""
 	@echo "  [language] = nodejs python dotnet go java"
 	@echo ""
@@ -205,6 +206,24 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+
+# Shadow-gen diff: generate the SDK both ways (legacy codegen binary vs
+# `pulumi package gen-sdk`) from the same schema.json into isolated temp dirs
+# and report any un-allowlisted difference. Exits non-zero if they disagree.
+# This never touches the committed sdk/ directory.
+#
+# TEMPORARY: this section exists only to verify the migration to
+# `pulumi package gen-sdk`. Once every provider+language has been migrated and
+# verified, this whole section is removed along with the comparison tooling.
+# See pulumi/ci-mgmt#2291.
+compare_sdks: compare_sdk_nodejs compare_sdk_python compare_sdk_dotnet compare_sdk_go compare_sdk_java
+compare_sdk_%: .make/mise_install bin/$(CODEGEN) .make/schema | mise_env
+	go run github.com/pulumi/ci-mgmt/provider-ci@master compare-sdk --language $*
+# Only the aggregate is .PHONY. The compare_sdk_<lang> targets must NOT be: make
+# does not apply a pattern rule's recipe to a target it knows is phony, so
+# marking them phony turns `make compare_sdk_<lang>` into a no-op ("Nothing to be
+# done"). They have no backing file, so they already re-run on every invocation.
+.PHONY: compare_sdks
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}


### PR DESCRIPTION
## Summary

Wires the shadow-gen diff (#2282) into the generated bridged-provider Makefile as a standard `make compare_sdk_<lang>` target, plus a `compare_sdks` aggregate over all configured languages. The target generates the SDK both ways and reports any un-allowlisted difference.

The target is emitted only when the provider has a schema (`not .Config.NoSchema`), depends on the codegen binary and schema so they build first, and invokes `provider-ci@master compare-sdk`, mirroring the existing `ci-mgmt` target. Regenerates the six checked-in base-template test-provider Makefiles; native and `noSchema` providers are correctly unaffected.

## What's next

The gated and scheduled CI workflow, then allowlist docs.

Part of #2282.
Part of pulumi/home#4787.
