### PR TITLE
Bump pinned pulumi CLI to 3.242.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 go = '1.24'
 golangci-lint = '2.2.2'
 node = '24.1.0'
-"github:pulumi/pulumi" = '3.183.0'
+"github:pulumi/pulumi" = '3.242.0'
 yarn = '1.22.22'
 dotnet = '8'
 shellcheck = '0.10.0'


### PR DESCRIPTION
## Summary

The mise pin for the pulumi CLI lagged well behind current releases, so any tool that shells out to `pulumi` ran against a stale CLI. In particular the `gen-sdk` codegen path exercised by the new `compare_sdk_<lang>` target (#2290) needs a current CLI to be a meaningful comparison. This bumps the pin from 3.183.0 to 3.242.0 so local and CI runs use a current pulumi.

Verified locally that `pulumi package gen-sdk` runs cleanly on 3.242.0 and the compare-sdk flow passes end to end against it. The newest published release is 3.245.0; this lands on 3.242.0 and can be moved forward separately if desired.
