### PR TITLE
Add shadow-gen diff as a central reusable CI workflow

### DIFF
--- a/.github/workflows/compare_sdk.yml
+++ b/.github/workflows/compare_sdk.yml
@@ -1,0 +1,112 @@
+# Reusable workflow: shadow-gen diff. Generates a provider's SDK both ways - via
+# the legacy per-provider codegen binary and via `pulumi package gen-sdk` - from
+# the same schema.json and reports any un-allowlisted difference.
+#
+# It is hosted centrally here in pulumi/ci-mgmt rather than baked into every
+# provider repo. Provider repos call it from their generated main.yml /
+# run-acceptance-tests.yml:
+#
+#   compare_sdk:
+#     needs: prerequisites
+#     uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+#     with:
+#       version: ${{ needs.prerequisites.outputs.version }}
+#       languages: '["nodejs","python","dotnet","go","java"]'
+#       runs-on: ubuntu-latest
+#       mise-version: <mise version>
+#       checkout-submodules: "false"
+#
+# TEMPORARY: this workflow exists only to track the migration to
+# `pulumi package gen-sdk`. It is informational and non-blocking. Once every
+# provider+language has been migrated and verified, it is removed along with the
+# rest of the comparison tooling. See pulumi/ci-mgmt#2291.
+name: compare_sdk
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Provider version. Only needed to satisfy the build; the comparison normalizes the version away.
+        required: true
+        type: string
+      languages:
+        description: JSON array of SDK languages to compare, e.g. '["nodejs","go"]'.
+        required: true
+        type: string
+      runs-on:
+        description: Runner label to execute on.
+        required: false
+        type: string
+        default: ubuntu-latest
+      mise-version:
+        description: Version of mise to install.
+        required: true
+        type: string
+      checkout-submodules:
+        description: Value passed to actions/checkout's submodules input.
+        required: false
+        type: string
+        default: "false"
+
+jobs:
+  compare_sdk:
+    name: compare_sdk (${{ matrix.language }})
+    # Job-level: keep the calling workflow non-blocking even if an infra step
+    # (checkout, mise, artifact restore) fails. The expected "SDKs differ" case is
+    # handled at the Compare step below so the check itself stays green.
+    continue-on-error: true
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+    env:
+      PROVIDER_VERSION: ${{ inputs.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(inputs.languages) }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: ${{ inputs.checkout-submodules }}
+          persist-credentials: false
+      - name: Setup mise
+        uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: ${{ inputs.mise-version }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cache_save: false
+      # Reuse the provider + codegen binary the prerequisites job already built
+      # and uploaded as the `prerequisites-bin` artifact. The provider's local
+      # download-prerequisites composite action is not reachable from a workflow
+      # hosted in ci-mgmt (local actions resolve against this repo, not the
+      # caller), so we restore the artifact directly here.
+      - name: Download prerequisites
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: prerequisites-bin
+          path: bin
+      - name: Restore executable permissions
+        shell: bash
+        run: |
+          if [ -f bin/executables.txt ]; then
+            while IFS= read -r f; do
+              [ -n "$f" ] && chmod +x "$f"
+            done < bin/executables.txt
+          fi
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Restore makefile progress
+        # Mark provider + schema as already built (the binaries came from the
+        # artifact, schema.json is committed) so the comparison does not rebuild.
+        run: make --touch provider schema
+      - name: Compare ${{ matrix.language }} SDK (legacy vs gen-sdk)
+        # The command writes its markdown report to $GITHUB_STEP_SUMMARY and exits
+        # non-zero when the SDKs differ. While the check is informational we
+        # tolerate that here so the job stays green; the diff is still visible in
+        # the step summary. Drop this continue-on-error to make a difference fail
+        # the check (gating) once parity holds. See pulumi/ci-mgmt#2291.
+        continue-on-error: true
+        run: make compare_sdk_${{ matrix.language }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/main.yml
@@ -37,6 +37,23 @@ jobs:
       id-token: write # For ESC secrets.
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '#{{ .Config.Languages | toJson }}#'
+      runs-on: #{{ if .Config.Runner.BuildSDK }}##{{- .Config.Runner.BuildSDK }}##{{ else }}##{{- .Config.Runner.Default }}##{{ end }}#
+      mise-version: #{{ .Config.MiseVersion }}#
+      checkout-submodules: '#{{ .Config.CheckoutSubmodules }}#'
   #{{- end }}#
 
   post_build:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -258,6 +258,25 @@ jobs:
       id-token: write # For ESC secrets.
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '#{{ .Config.Languages | toJson }}#'
+      runs-on: #{{ if .Config.Runner.BuildSDK }}##{{- .Config.Runner.BuildSDK }}##{{ else }}##{{- .Config.Runner.Default }}##{{ end }}#
+      mise-version: #{{ .Config.MiseVersion }}#
+      checkout-submodules: '#{{ .Config.CheckoutSubmodules }}#'
   #{{- end }}#
 
   comment-notification:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -43,6 +43,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'true'
+
   post_build:
     name: post_build
     needs: prerequisites

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -234,6 +234,25 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'true'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -41,6 +41,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: pulumi-ubuntu-8core
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   post_build:
     name: post_build
     needs: prerequisites

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -234,6 +234,25 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: pulumi-ubuntu-8core
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -53,6 +53,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   post_build:
     name: post_build
     needs: prerequisites

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -233,6 +233,25 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/provider-ci/test-providers/eks/.github/workflows/master.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/master.yml
@@ -50,6 +50,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   post_build:
     name: post_build
     needs: prerequisites

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -232,6 +232,25 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/main.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/main.yml
@@ -46,6 +46,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   post_build:
     name: post_build
     needs: prerequisites

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/run-acceptance-tests.yml
@@ -73,6 +73,25 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/provider-ci/test-providers/xyz/.github/workflows/main.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/main.yml
@@ -43,6 +43,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   post_build:
     name: post_build
     needs: prerequisites

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -217,6 +217,25 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
+  # Shadow-gen diff: informational, non-blocking comparison of legacy codegen vs
+  # `pulumi package gen-sdk`. The logic lives centrally in pulumi/ci-mgmt; this is
+  # only a thin reference. TEMPORARY - removed once the migration is verified
+  # (pulumi/ci-mgmt#2291).
+  compare_sdk:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: compare_sdk
+    needs: prerequisites
+    uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      languages: '["nodejs","python","dotnet","go","java"]'
+      runs-on: ubuntu-latest
+      mise-version: 2026.3.7
+      checkout-submodules: 'false'
+
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification


### PR DESCRIPTION
## Summary

We're migrating SDK generation from the legacy per-provider codegen binaries to the generic `pulumi package gen-sdk`. To trust that switch, we need ongoing proof that both paths produce the same SDK, per provider and language. This PR adds that verification to provider CI: it runs `make compare_sdk_<lang>` (legacy vs gen-sdk) as an informational, non-blocking, parallel check. TEMPORARY, removed once the migration is verified (pulumi/ci-mgmt#2291).

**Experiment:** instead of baking the workflow into all ~86 provider repos, this hosts it once here as a reusable workflow (`.github/workflows/compare_sdk.yml`) and has providers reference it remotely (`uses: pulumi/ci-mgmt/.github/workflows/compare_sdk.yml@master`). Template variables become workflow inputs, so each provider carries only a thin calling job and the logic is updated in one place. This is the first cross-repo reusable-workflow call from a provider into ci-mgmt, and it follows the "make workflows dumb" direction.

## What it does

- New `workflow_call` workflow with inputs (`version`, `languages`, `runs-on`, `mise-version`, `checkout-submodules`); `languages` expands via `fromJSON` into a per-language matrix.
- Thin `compare_sdk` calling job generated into bridged `main.yml` / `run-acceptance-tests.yml` (gated `not NoSchema`, fork-guarded on PRs).
- Non-blocking (`continue-on-error`) and parallel; report goes to `$GITHUB_STEP_SUMMARY`. Reuses the `prerequisites-bin` build (no rebuild) and needs only the auto `GITHUB_TOKEN` (no ESC, no cloud creds).

## Verified

`make all` green (deterministic generation, tests, 0 lint issues); `actionlint` passes on the new workflow and the regenerated providers. The `make compare_sdk_<lang>` path was smoke-tested end to end locally.

## End-to-end validation

Validated against a real provider via throwaway PRs [pulumi/pulumi-xyz#2430](https://github.com/pulumi/pulumi-xyz/pull/2430) and [#2452](https://github.com/pulumi/pulumi-xyz/pull/2452) (the latter after the version fix), pinning the refs to this branch (neither the workflow nor the `compare-sdk` command is on `master` yet). Attempts:

- **Attempt 1** ([run](https://github.com/pulumi/pulumi-xyz/actions/runs/26962301718)): `compare_sdk` jobs went green but the comparison never ran (`make compare_sdk_<lang>` printed "Nothing to be done"). Cause: the generated `.PHONY` line marked the per-language pattern targets phony, which stops Make applying the pattern rule's recipe. Fixed in #2290 so only the `compare_sdks` aggregate is phony.
- **Attempt 2** ([run](https://github.com/pulumi/pulumi-xyz/actions/runs/26963225007)): the recipe ran, but `go run .../provider-ci@<branch>` failed because Go rejects a branch ref containing slashes ("disallowed version string"). Test-harness artifact only, the real recipe uses `@master`; worked around by pinning the test recipe to the commit SHA.
- **Attempt 3** ([run](https://github.com/pulumi/pulumi-xyz/actions/runs/26963625336)): the comparison ran end to end and reported real differences for xyz (java: 88.2% parity, 15/17 files identical, `Pulumi.yaml` only in legacy). This confirms the centralized path works: reuse the prerequisites build, run legacy codegen + `pulumi package gen-sdk`, write the report to the step summary. The jobs showed red because the command exits non-zero on a real diff, so the comparison step now tolerates that (`continue-on-error`) to keep the check green while informational; the diff stays in the summary.
- **Attempt 4** ([run](https://github.com/pulumi/pulumi-xyz/actions/runs/26963625336/attempts/2)): re-ran with the step-level `continue-on-error` fix. All five `compare_sdk` checks are now green while still running the comparison and reporting diffs (java's summary still shows 88.2% parity). End-to-end behavior confirmed.
- **Attempt 5** ([run](https://github.com/pulumi/pulumi-xyz/actions/runs/27013373133)): most of those diffs were version noise. The legacy binary bakes its build version via ldflags while gen-sdk used a synthetic default, so version-bearing files (`build.gradle`, `.csproj`, `version.txt`, `pulumiUtilities.go`) differed on the version string alone. Fixed in #2288: the command now defaults `--version` to `PROVIDER_VERSION` so both sides embed the same version. Parity jumped (java 94.1%, go 91.7%, dotnet 93.8%, nodejs 94.7%, python 94.1%), leaving one genuine diff per language: `Pulumi.yaml (only in legacy)` (legacy tfgen emits an SDK-root `Pulumi.yaml` that gen-sdk does not).

## Notes

- Cannot execute until it lands on ci-mgmt `master` (providers reference `@master`); `actionlint` does not resolve remote reusable workflows, so generation stays green.
- Requires the org Actions policy to allow calling ci-mgmt reusable workflows from provider repos.

Stacked on #2290 (base `pose/chores/compare-sdk-make-target-2282`), which stacks on #2288. Merge order: #2288, #2290, this.

Part of pulumi/home#4787.
