### PR TITLE
Bump provider-version & git-status-check actions to v2.0.0 (Node 24)

### DIFF
--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -74,7 +74,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
 
       - name: pulumi/provider-version-action
-        uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+        uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
 
       - name: pulumi/auth-actions
         uses: pulumi/auth-actions@141415910c3beb54e03b48e9057c204c97b956f2 # v2.1.0
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: pulumi/git-status-check-action
-        uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
 
       - name: peter-evans/create-or-update-comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -194,7 +194,7 @@ jobs:
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       env:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -125,7 +125,7 @@ jobs:
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -211,7 +211,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -236,7 +236,7 @@ jobs:
     #{{- end }}##{{ end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -328,7 +328,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -468,7 +468,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -545,7 +545,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -39,7 +39,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -114,7 +114,7 @@ jobs:
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -200,7 +200,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -223,7 +223,7 @@ jobs:
     #{{- end }}##{{ end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -288,7 +288,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -428,7 +428,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -505,7 +505,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -587,7 +587,7 @@ jobs:
     #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -628,7 +628,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -114,7 +114,7 @@ jobs:
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -201,7 +201,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -225,7 +225,7 @@ jobs:
     #{{- end }}##{{ end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -290,7 +290,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -430,7 +430,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -507,7 +507,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -589,7 +589,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -630,7 +630,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -67,7 +67,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -142,7 +142,7 @@ jobs:
     #{{- end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -279,7 +279,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -311,7 +311,7 @@ jobs:
     #{{- end }}##{{ end }}#
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -420,7 +420,7 @@ jobs:
 #{{- end }}#
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -110,7 +110,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -198,7 +198,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -217,7 +217,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -320,7 +320,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -411,7 +411,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -483,7 +483,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -49,7 +49,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -102,7 +102,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -190,7 +190,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -209,7 +209,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -276,7 +276,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -367,7 +367,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -439,7 +439,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -527,7 +527,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -568,7 +568,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -102,7 +102,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -190,7 +190,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -209,7 +209,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -276,7 +276,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -367,7 +367,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -439,7 +439,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -527,7 +527,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -568,7 +568,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -78,7 +78,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -131,7 +131,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -270,7 +270,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -298,7 +298,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -413,7 +413,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -70,7 +70,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 7

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -197,7 +197,7 @@ jobs:
         PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       env:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -67,7 +67,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 6

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -197,7 +197,7 @@ jobs:
       run: make build_registry_docs
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       env:

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -73,7 +73,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -147,7 +147,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -162,7 +162,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -356,7 +356,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -437,7 +437,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -49,7 +49,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -65,7 +65,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -139,7 +139,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -154,7 +154,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -221,7 +221,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -312,7 +312,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -393,7 +393,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -481,7 +481,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -522,7 +522,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -65,7 +65,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -139,7 +139,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -154,7 +154,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -221,7 +221,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -312,7 +312,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -393,7 +393,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -481,7 +481,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -522,7 +522,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -78,7 +78,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -94,7 +94,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -219,7 +219,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -243,7 +243,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -358,7 +358,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -119,7 +119,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -197,7 +197,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -214,7 +214,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -317,7 +317,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -423,7 +423,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -504,7 +504,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -60,7 +60,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -111,7 +111,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -189,7 +189,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -206,7 +206,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -273,7 +273,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -379,7 +379,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -460,7 +460,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -548,7 +548,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -589,7 +589,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -111,7 +111,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -189,7 +189,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -206,7 +206,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -273,7 +273,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -379,7 +379,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -460,7 +460,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -548,7 +548,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -589,7 +589,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -89,7 +89,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -140,7 +140,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -269,7 +269,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -295,7 +295,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -410,7 +410,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -72,7 +72,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 4

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -196,7 +196,7 @@ jobs:
       run: make build_registry_docs
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       env:

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -69,7 +69,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 4

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -195,7 +195,7 @@ jobs:
         PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       env:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -114,7 +114,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -189,7 +189,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -206,7 +206,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -309,7 +309,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -392,7 +392,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -473,7 +473,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -106,7 +106,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -181,7 +181,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -348,7 +348,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -429,7 +429,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -517,7 +517,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -558,7 +558,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -106,7 +106,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -181,7 +181,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -348,7 +348,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -429,7 +429,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -517,7 +517,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -558,7 +558,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -84,7 +84,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -135,7 +135,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -261,7 +261,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -287,7 +287,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -402,7 +402,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -114,7 +114,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -189,7 +189,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -206,7 +206,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -309,7 +309,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -392,7 +392,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -473,7 +473,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -106,7 +106,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -181,7 +181,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -348,7 +348,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -429,7 +429,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -517,7 +517,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -558,7 +558,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -106,7 +106,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -181,7 +181,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -348,7 +348,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -429,7 +429,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -517,7 +517,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -558,7 +558,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -84,7 +84,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -135,7 +135,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -261,7 +261,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -287,7 +287,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -402,7 +402,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -114,7 +114,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -189,7 +189,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -206,7 +206,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -309,7 +309,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -393,7 +393,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -474,7 +474,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -106,7 +106,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -181,7 +181,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -349,7 +349,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -430,7 +430,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -518,7 +518,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -559,7 +559,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -106,7 +106,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -181,7 +181,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -265,7 +265,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -349,7 +349,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -430,7 +430,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -518,7 +518,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -559,7 +559,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -84,7 +84,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -135,7 +135,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -261,7 +261,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -287,7 +287,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -402,7 +402,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -116,7 +116,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -191,7 +191,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -206,7 +206,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -310,7 +310,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -418,7 +418,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -499,7 +499,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -108,7 +108,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -183,7 +183,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -266,7 +266,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -374,7 +374,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -455,7 +455,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -543,7 +543,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -584,7 +584,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -108,7 +108,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -183,7 +183,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -198,7 +198,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -266,7 +266,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -374,7 +374,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -455,7 +455,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -543,7 +543,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -584,7 +584,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -84,7 +84,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -137,7 +137,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -263,7 +263,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -287,7 +287,7 @@ jobs:
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -402,7 +402,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -107,7 +107,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -182,7 +182,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -199,7 +199,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -302,7 +302,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -380,7 +380,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -461,7 +461,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
@@ -48,7 +48,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -99,7 +99,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -174,7 +174,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -191,7 +191,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -258,7 +258,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -336,7 +336,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -417,7 +417,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -505,7 +505,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -546,7 +546,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -99,7 +99,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -174,7 +174,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -191,7 +191,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -258,7 +258,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -336,7 +336,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -417,7 +417,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -505,7 +505,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -546,7 +546,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -77,7 +77,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -128,7 +128,7 @@ jobs:
       run: make provider
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -254,7 +254,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:
@@ -280,7 +280,7 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
       with:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
@@ -395,7 +395,7 @@ jobs:
         owner: ${{ github.repository_owner }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+      uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       with:
         set-env: PROVIDER_VERSION
       env:

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -65,7 +65,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 0

--- a/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/prerequisites.yml
@@ -61,7 +61,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 0

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Check worktree clean
         id: worktreeClean
-        uses: pulumi/git-status-check-action@v1
+        uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
         with:
           # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -62,7 +62,7 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - uses: pulumi/provider-version-action@3a647064cf4697c7c6352b9a1d9e554450cbe957 # v1.6.1
+    - uses: pulumi/provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0
       id: provider-version
       with:
         major-version: 1

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -180,7 +180,7 @@ jobs:
         PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     - name: Check worktree clean
       id: worktreeClean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       env:


### PR DESCRIPTION
## Summary

Bumps `pulumi/provider-version-action` and `pulumi/git-status-check-action` to their new **v2.0.0** releases, which move the action runtime from Node 20 to Node 24. GitHub is removing the Node 20 actions runtime from runners, so steps pinned to the v1 majors emit a runtime deprecation warning. The action interfaces (inputs/outputs) are unchanged between v1 and v2, so this is a version-only bump with no workflow-logic changes.

## Changes

- `provider-ci/internal/pkg/action-versions.yml` (the Renovate source of truth): both entries bumped to the v2.0.0 commit SHAs.
- All generated workflow references updated to match: `provider-version-action@c4f719182e607d0d8322f148f168d3372838e681 # v2.0.0` and `git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2.0.0`.
- The two bridged `git-status-check-action` references in `base/build_sdk.yml` and `base/run-acceptance-tests.yml` previously used the floating `@v1` branch ref. They are now SHA-pinned to v2.0.0 to match the convention used for every other action, so Renovate manages future bumps consistently.
- Regenerated all 15 test-providers via `make gen`.

## Verification

- `make gen` regenerates cleanly; the full diff is version-string only (no logic changes).
- `actionlint` passes on all regenerated test-provider workflows.

Part of pulumi/home#4808
