### PR TITLE
lint-actions: ignore gh-aw maintenance empty-option; pin actionlint via mise

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -17,6 +17,13 @@ paths:
       # recognize the `queue` key, so it false-positives this valid syntax.
       - 'unexpected key "queue" for "concurrency" section'
 
+  ".github/workflows/agentics-maintenance.yml":
+    ignore:
+      # gh-aw emits an empty choice option ('') so the optional maintenance
+      # operation can default to "no operation". This is valid GitHub Actions,
+      # but actionlint's syntax-check flags the empty string.
+      - 'string should not be empty'
+
   ".github/workflows/build_provider.yml":
     ignore:
       - 'property ".*" is not defined in object type {}'

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -25,8 +25,14 @@ jobs:
         uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Install mise
+        uses: jdx/mise-action@c6a35e2d7dc8cf1493e7465af7460b4748cd4806
+        with:
+          version: 2026.3.7
+          install: false
+      - name: Install actionlint and shellcheck
+        run: mise install actionlint shellcheck
+        shell: bash
       - name: lint workflows
-        run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        run: actionlint -color
         shell: bash

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@ node = '24.1.0'
 yarn = '1.22.22'
 dotnet = '8'
 shellcheck = '0.10.0'
+actionlint = '1.7.12'
 "npm:@anthropic-ai/claude-code" = '2.1.52'
 bun = '1.3.6'
 [tools."github:github/gh-aw"]


### PR DESCRIPTION
gh-aw 0.80.9 generates `.github/workflows/agentics-maintenance.yml` with an empty `workflow_dispatch` choice option (`- ''`) so the optional `operation` can default to no-op. That is valid GitHub Actions, but actionlint's `syntax-check` rejects the empty string and fails `lint-actions`.

Add a scoped `ignore` for that file in `.github/actionlint.yaml`, mirroring the existing `concurrency.queue: max` gh-aw false-positive ignore. The empty option is rejected by every actionlint release tested (1.6.27 through 1.7.12), so suppressing the false positive is the fix rather than a version pin.

Also pin `actionlint` in `mise.toml` and run it from the mise toolchain in `lint-actions.yml`, replacing `bash <(curl .../download-actionlint.bash)`. This removes the pipe-to-shell install and the always-latest moving target.

Verified by regenerating the maintenance file with gh-aw 0.80.9 and running `actionlint` over the repo (exit 0).

Part of #2327