### PR TITLE
Build provider binary in fanout test_provider job when opted in

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -303,6 +303,17 @@ type Config struct {
 	// This function is called without arguments to run unit tests for the provider binary.
 	TestProviderCmd string `yaml:"testProviderCmd"`
 
+	// TestProviderNeedsProviderBinary builds the provider binary in the
+	// standalone acceptance test_provider job before running unit tests. Set
+	// this for providers whose `make test_provider` suite includes tests that
+	// load the built provider plugin from ./bin (e.g. pulumitest program
+	// tests). Defaults to false so the fanout test_provider job stays
+	// lightweight for providers that do not need the binary. The build uses
+	// `make provider_no_deps`, which relies on the schema-embed.json restored
+	// from the prerequisites artifact and so does not regenerate the schema.
+	// See pulumi/ci-mgmt#2336.
+	TestProviderNeedsProviderBinary bool `yaml:"testProviderNeedsProviderBinary"`
+
 	// Customizes the Make function renovate_cmd.
 	//
 	// This function is called by the make renovate target after the Renovate bot has finished updating

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -111,6 +111,14 @@ jobs:
         GITHUB_TOKEN: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
     - name: Restore prerequisites
       uses: ./.github/actions/download-prerequisites
+    #{{- if .Config.TestProviderNeedsProviderBinary }}#
+    # Some providers' unit tests load the built provider plugin from ./bin. The
+    # restored prerequisites artifact only contains the tfgen binary, so build
+    # the provider here. provider_no_deps reuses the restored schema-embed.json
+    # and does not regenerate the schema. See pulumi/ci-mgmt#2336.
+    - name: Build provider binary
+      run: make provider_no_deps
+    #{{- end }}#
     - name: Unit-test provider code
       run: make test_provider
       env:

--- a/provider-ci/test-providers/xyz/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/xyz/.ci-mgmt.yaml
@@ -18,3 +18,6 @@ freeDiskSpaceBeforeBuild: false
 freeDiskSpaceBeforeTest: false
 freeDiskSpaceBeforeSdkBuild: false
 publishRegistry: false
+# Exercise building the provider binary in the fanout test_provider job for
+# providers whose unit tests load the plugin from ./bin. See pulumi/ci-mgmt#2336.
+testProviderNeedsProviderBinary: true

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -107,6 +107,12 @@ jobs:
         GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
     - name: Restore prerequisites
       uses: ./.github/actions/download-prerequisites
+    # Some providers' unit tests load the built provider plugin from ./bin. The
+    # restored prerequisites artifact only contains the tfgen binary, so build
+    # the provider here. provider_no_deps reuses the restored schema-embed.json
+    # and does not regenerate the schema. See pulumi/ci-mgmt#2336.
+    - name: Build provider binary
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
       env:


### PR DESCRIPTION
Adds an opt-in `testProviderNeedsProviderBinary` flag. When set, the fanout `test_provider` job runs `make provider_no_deps` before the unit tests, so providers whose unit tests load the built provider plugin from `./bin` work. Default off keeps the job lightweight for every other provider. All 15 test providers regenerate deterministically; only the opted-in `xyz` golden gains the new step.

Part of #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)
