### PR TITLE
Isolate Azure CLI config dir when signing Windows binaries

### DIFF
--- a/provider-ci/internal/pkg/templates/base/scripts/crossbuild.mk
+++ b/provider-ci/internal/pkg/templates/base/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/aws/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/aws/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/cloudflare/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/cloudflare/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/docker/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/docker/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/eks/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/eks/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/pulumiservice/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/pulumiservice/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/terraform-module/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/terraform-module/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 

--- a/provider-ci/test-providers/xyz/scripts/crossbuild.mk
+++ b/provider-ci/test-providers/xyz/scripts/crossbuild.mk
@@ -39,6 +39,9 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
 		else \
 			mv $@ $@.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -55,7 +58,6 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$@.unsigned; \
 			mv $@.unsigned $@; \
-			az logout; \
 		fi; \
 	fi
 


### PR DESCRIPTION
Applies the same isolation to the templated `base/scripts/crossbuild.mk`: each windows-signing invocation gets its own `AZURE_CONFIG_DIR` so concurrent per-arch signing can't share `~/.azure` and race on `accounts.json`, with the explicit `az logout` replaced by trap-based temp-dir cleanup. Test-provider fixtures regenerated via `make test-providers` (deterministic; 7 bridged/generic fixtures updated, actionlint clean).

Part of pulumi/home#4671
