### PR TITLE
Bump Node version to v24.18.0

### DIFF
--- a/provider-ci/internal/pkg/templates/all/.config/mise.toml
+++ b/provider-ci/internal/pkg/templates/all/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/aws-native/.config/mise.toml
+++ b/provider-ci/test-providers/aws-native/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/aws/.config/mise.toml
+++ b/provider-ci/test-providers/aws/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/cloudflare/.config/mise.toml
+++ b/provider-ci/test-providers/cloudflare/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/command/.config/mise.toml
+++ b/provider-ci/test-providers/command/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/docker-build/.config/mise.toml
+++ b/provider-ci/test-providers/docker-build/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/docker/.config/mise.toml
+++ b/provider-ci/test-providers/docker/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/eks/.config/mise.toml
+++ b/provider-ci/test-providers/eks/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-coredns/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/kubernetes/.config/mise.toml
+++ b/provider-ci/test-providers/kubernetes/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/pulumiservice/.config/mise.toml
+++ b/provider-ci/test-providers/pulumiservice/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/terraform-module/.config/mise.toml
+++ b/provider-ci/test-providers/terraform-module/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered

--- a/provider-ci/test-providers/xyz/.config/mise.toml
+++ b/provider-ci/test-providers/xyz/.config/mise.toml
@@ -9,7 +9,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 
 # Runtimes
 go = "{{ env.GO_VERSION_MISE }}"
-node = '20.19.5'
+node = '24.18.0'
 python = '3.11.8'
 "vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered


### PR DESCRIPTION
Due to https://github.com/pulumi/pulumi/pull/23722, provider builds are failing on Node:
- https://github.com/pulumi/pulumi-ec/actions/runs/28541996292/job/84618714819
- https://github.com/pulumi/pulumi-aiven/actions/runs/28549383407

This will affect any test run on any provider since we always build with the latest Pulumi.

Fixes https://github.com/pulumi/pulumi-aiven/issues/1221, https://github.com/pulumi/pulumi-ec/issues/839 and prevents an untold amount of future build failure issues.


