### PR TITLE
Add upgrade provider runner config

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -133,10 +133,11 @@ type Config struct {
 	// These are not overridden by any providers:
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22runner%3A%22&type=code
 	Runner struct {
-		Default       string `yaml:"default"`
-		Prerequisites string `yaml:"prerequisites"`
-		BuildSDK      string `yaml:"buildSdk"`
-		Publish       string `yaml:"publish"`
+		Default         string `yaml:"default"`
+		Prerequisites   string `yaml:"prerequisites"`
+		BuildSDK        string `yaml:"buildSdk"`
+		Publish         string `yaml:"publish"`
+		UpgradeProvider string `yaml:"upgradeProvider"`
 	} `yaml:"runner"`
 
 	// actionVersions should be used wherever we use external actions to make

--- a/provider-ci/internal/pkg/config_test.go
+++ b/provider-ci/internal/pkg/config_test.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -175,5 +176,35 @@ func TestGeneratePackageDeletesLegacyProviderPrefixedAgenticWorkflows(t *testing
 		if _, err := os.Stat(filepath.Join(outDir, path)); err != nil {
 			t.Fatalf("expected %s to exist, got err %v", path, err)
 		}
+	}
+}
+
+func TestGeneratePackageUsesUpgradeProviderRunner(t *testing.T) {
+	outDir := t.TempDir()
+
+	config, err := loadDefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Provider = "aws"
+	config.ESC.Enabled = true
+	config.Runner.UpgradeProvider = "ubuntu-24.04"
+
+	if err := GeneratePackage(GenerateOpts{
+		RepositoryName: "pulumi/pulumi-aws",
+		OutDir:         outDir,
+		TemplateName:   "bridged-provider",
+		Config:         config,
+		SkipMigrations: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	workflow, err := os.ReadFile(filepath.Join(outDir, ".github/workflows/upgrade-provider.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(workflow), "    runs-on: ubuntu-24.04\n") {
+		t.Fatalf("expected upgrade-provider workflow to use custom runner, got:\n%s", workflow)
 	}
 }

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   upgrade_provider:
     name: upgrade-provider
-    runs-on: #{{ .Config.Runner.Default }}#
+    runs-on: #{{ if .Config.Runner.UpgradeProvider }}##{{- .Config.Runner.UpgradeProvider }}##{{ else }}##{{- .Config.Runner.Default }}##{{ end }}#
     steps:
       #{{- if .Config.FreeDiskSpaceBeforeBuild }}#
       # Run as first step so we don't delete things that have just been installed

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -137,6 +137,7 @@ runner:
   prerequisites: ubuntu-latest
   # publish: ubuntu-latest
   # buildSdk: ubuntu-latest
+  # upgradeProvider: ubuntu-latest
 
 # publish contains multiple properties relating to the publish jobs.
 # Used by 2 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22publish%3A%22&type=code


### PR DESCRIPTION
## Summary
- add `runner.upgradeProvider` to `.ci-mgmt.yaml` config
- use it for the generated bridged `upgrade-provider.yml` workflow, falling back to `runner.default`
- add generation coverage for the custom runner rendering

## Motivation

The pulumi-aws upgrade-provider workflow has been failing due to resource limits.

## Testing
- `cd provider-ci && make all`
- `git diff --check`