### PR TITLE
Harden managed skills update workflow

### DIFF
--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/update-skills.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/update-skills.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 9 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write # For ESC secrets.
 
 jobs:
   update-skills:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: #{{ .Config.ActionVersions.Checkout }}#
+        with:
+          persist-credentials: false
 
       - name: Check for skills lockfile
         id: skills-lock
@@ -30,12 +32,17 @@ jobs:
 
       - name: Update skills
         if: steps.skills-lock.outputs.exists == 'true'
-        run: npx --yes skills@latest update -y
+        run: npx --yes skills@1.5.16 update -y
+#{{ .Config | renderEscStep | trim | nindent 6 }}#
 
       - name: Create pull request
         if: steps.skills-lock.outputs.exists == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          add-paths: |
+            .agents/skills
+            .claude/skills
+            skills-lock.json
           author: Pulumi Bot <bot@pulumi.com>
           branch: update-skills
           commit-message: "[internal] Update repository skills"
@@ -43,9 +50,10 @@ jobs:
           delete-branch: true
           labels: "impact/no-changelog-required"
           title: "Update repository skills"
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           body: |
             This PR updates repository skills by running:
 
             ```sh
-            npx --yes skills@latest update -y
+            npx --yes skills@1.5.16 update -y
             ```

--- a/provider-ci/test-providers/aws/.github/workflows/update-skills.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/update-skills.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 9 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write # For ESC secrets.
 
 jobs:
   update-skills:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for skills lockfile
         id: skills-lock
@@ -30,12 +32,26 @@ jobs:
 
       - name: Update skills
         if: steps.skills-lock.outputs.exists == 'true'
-        run: npx --yes skills@latest update -y
+        run: npx --yes skills@1.5.16 update -y
+
+      - env:
+          ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+          ESC_ACTION_OIDC_AUTH: "true"
+          ESC_ACTION_OIDC_ORGANIZATION: pulumi
+          ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+        id: esc-secrets
+        name: Fetch secrets from ESC
+        uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
 
       - name: Create pull request
         if: steps.skills-lock.outputs.exists == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          add-paths: |
+            .agents/skills
+            .claude/skills
+            skills-lock.json
           author: Pulumi Bot <bot@pulumi.com>
           branch: update-skills
           commit-message: "[internal] Update repository skills"
@@ -43,9 +59,10 @@ jobs:
           delete-branch: true
           labels: "impact/no-changelog-required"
           title: "Update repository skills"
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           body: |
             This PR updates repository skills by running:
 
             ```sh
-            npx --yes skills@latest update -y
+            npx --yes skills@1.5.16 update -y
             ```

--- a/provider-ci/test-providers/cloudflare/.github/workflows/update-skills.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/update-skills.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 9 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write # For ESC secrets.
 
 jobs:
   update-skills:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for skills lockfile
         id: skills-lock
@@ -30,12 +32,26 @@ jobs:
 
       - name: Update skills
         if: steps.skills-lock.outputs.exists == 'true'
-        run: npx --yes skills@latest update -y
+        run: npx --yes skills@1.5.16 update -y
+
+      - env:
+          ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+          ESC_ACTION_OIDC_AUTH: "true"
+          ESC_ACTION_OIDC_ORGANIZATION: pulumi
+          ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+        id: esc-secrets
+        name: Fetch secrets from ESC
+        uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
 
       - name: Create pull request
         if: steps.skills-lock.outputs.exists == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          add-paths: |
+            .agents/skills
+            .claude/skills
+            skills-lock.json
           author: Pulumi Bot <bot@pulumi.com>
           branch: update-skills
           commit-message: "[internal] Update repository skills"
@@ -43,9 +59,10 @@ jobs:
           delete-branch: true
           labels: "impact/no-changelog-required"
           title: "Update repository skills"
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           body: |
             This PR updates repository skills by running:
 
             ```sh
-            npx --yes skills@latest update -y
+            npx --yes skills@1.5.16 update -y
             ```

--- a/provider-ci/test-providers/docker/.github/workflows/update-skills.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/update-skills.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 9 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write # For ESC secrets.
 
 jobs:
   update-skills:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for skills lockfile
         id: skills-lock
@@ -30,12 +32,26 @@ jobs:
 
       - name: Update skills
         if: steps.skills-lock.outputs.exists == 'true'
-        run: npx --yes skills@latest update -y
+        run: npx --yes skills@1.5.16 update -y
+
+      - env:
+          ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+          ESC_ACTION_OIDC_AUTH: "true"
+          ESC_ACTION_OIDC_ORGANIZATION: pulumi
+          ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+        id: esc-secrets
+        name: Fetch secrets from ESC
+        uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
 
       - name: Create pull request
         if: steps.skills-lock.outputs.exists == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          add-paths: |
+            .agents/skills
+            .claude/skills
+            skills-lock.json
           author: Pulumi Bot <bot@pulumi.com>
           branch: update-skills
           commit-message: "[internal] Update repository skills"
@@ -43,9 +59,10 @@ jobs:
           delete-branch: true
           labels: "impact/no-changelog-required"
           title: "Update repository skills"
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           body: |
             This PR updates repository skills by running:
 
             ```sh
-            npx --yes skills@latest update -y
+            npx --yes skills@1.5.16 update -y
             ```

--- a/provider-ci/test-providers/xyz/.github/workflows/update-skills.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/update-skills.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 9 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write # For ESC secrets.
 
 jobs:
   update-skills:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for skills lockfile
         id: skills-lock
@@ -30,12 +32,26 @@ jobs:
 
       - name: Update skills
         if: steps.skills-lock.outputs.exists == 'true'
-        run: npx --yes skills@latest update -y
+        run: npx --yes skills@1.5.16 update -y
+
+      - env:
+          ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+          ESC_ACTION_OIDC_AUTH: "true"
+          ESC_ACTION_OIDC_ORGANIZATION: pulumi
+          ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+        id: esc-secrets
+        name: Fetch secrets from ESC
+        uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
 
       - name: Create pull request
         if: steps.skills-lock.outputs.exists == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          add-paths: |
+            .agents/skills
+            .claude/skills
+            skills-lock.json
           author: Pulumi Bot <bot@pulumi.com>
           branch: update-skills
           commit-message: "[internal] Update repository skills"
@@ -43,9 +59,10 @@ jobs:
           delete-branch: true
           labels: "impact/no-changelog-required"
           title: "Update repository skills"
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           body: |
             This PR updates repository skills by running:
 
             ```sh
-            npx --yes skills@latest update -y
+            npx --yes skills@1.5.16 update -y
             ```


### PR DESCRIPTION
## Summary
- Restrict managed skill update PRs to `.agents/skills`, `.claude/skills`, and `skills-lock.json`.
- Authenticate `create-pull-request` with the Pulumi bot token fetched from ESC so the PR is opened by `pulumi-bot` and triggers normal PR workflows.
- Pin the skills CLI to `skills@1.5.16` and stop persisting checkout credentials.

## Root cause
The skills CLI detects the repository's Universal and Claude Code installations, but its noninteractive update path invokes its internal install without preserving those targets. On a clean Actions runner, the install falls back to every supported agent, including Eve's `agent/skills` directory. The unrestricted PR action then committed that unexpected directory in [pulumi-aws#6533](https://github.com/pulumi/pulumi-aws/pull/6533).

The workflow also set the commit author and committer to Pulumi Bot but did not pass a bot credential to `create-pull-request`, so GitHub created the PR as `github-actions`.

## Impact
Unexpected directories generated by the CLI are left out of update PRs. Expected skill and lockfile updates continue to be published, and the resulting PRs are created by the Pulumi bot account.

## Testing
- `cd provider-ci && mise exec -- make all`
- `git diff --check`
- `actionlint` on the generated aws, cloudflare, docker, and xyz workflows