### PR TITLE
Add coreweave to the ecosystem providers issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
+++ b/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
@@ -60,6 +60,7 @@ assignees: ''
 - [ ] [cloudngfwaws](https://github.com/pulumi/pulumi-cloudngfwaws)
 - [ ] [confluentcloud](https://github.com/pulumi/pulumi-confluentcloud)
 - [ ] [consul](https://github.com/pulumi/pulumi-consul)
+- [ ] [coreweave](https://github.com/pulumi/pulumi-coreweave)
 - [ ] [databricks](https://github.com/pulumi/pulumi-databricks)
 - [ ] [dbtcloud](https://github.com/pulumi/pulumi-dbtcloud)
 - [ ] [dnsimple](https://github.com/pulumi/pulumi-dnsimple)


### PR DESCRIPTION
`coreweave` is listed in `provider-ci/providers.json` but was missing from the ecosystem providers issue template, so manual rollout issues do not track it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
