### PR TITLE
fix(workflows): pass schema reports by file

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -157,8 +157,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -180,7 +180,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
 #{{- if .Config.EnableConfigurationCheck }}#
     - if: inputs.acceptance_fanout == false && inputs.is_pr
@@ -233,8 +233,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -256,7 +256,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
 #{{- if .Config.EnableConfigurationCheck }}#
     - if: inputs.is_pr

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -157,12 +157,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -179,13 +180,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
 #{{- if .Config.EnableConfigurationCheck }}#
     - if: inputs.acceptance_fanout == false && inputs.is_pr
@@ -238,12 +233,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -260,13 +256,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
 #{{- if .Config.EnableConfigurationCheck }}#
     - if: inputs.is_pr

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -208,8 +208,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -231,7 +231,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
 #{{- if .Config.EnableConfigurationCheck }}#
     - if: github.event_name == 'pull_request'

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -208,12 +208,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -230,13 +231,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
 #{{- if .Config.EnableConfigurationCheck }}#
     - if: github.event_name == 'pull_request'

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -94,13 +94,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -121,7 +121,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -92,14 +92,17 @@ jobs:
     #{{- if not .Config.NoSchema }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -118,10 +121,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -81,14 +81,17 @@ jobs:
     #{{- if not .Config.NoSchema }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -107,10 +110,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -83,13 +83,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -110,7 +110,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -81,14 +81,17 @@ jobs:
     #{{- if not .Config.NoSchema }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -107,10 +110,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -83,13 +83,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -110,7 +110,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -109,14 +109,17 @@ jobs:
     #{{- if not .Config.NoSchema }}#
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -135,10 +138,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -111,13 +111,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -138,7 +138,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -82,13 +82,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -109,7 +109,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -80,14 +80,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -106,10 +109,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -74,13 +74,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -101,7 +101,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -72,14 +72,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -98,10 +101,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -74,13 +74,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -101,7 +101,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -72,14 +72,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -98,10 +101,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -103,13 +103,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -130,7 +130,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -101,14 +101,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -127,10 +130,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -140,12 +140,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -162,13 +163,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -140,8 +140,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -163,7 +163,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -203,12 +203,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -225,13 +226,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -203,8 +203,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -226,7 +226,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -142,8 +142,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -165,7 +165,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -142,12 +142,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -164,13 +165,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -203,12 +203,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -225,13 +226,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -203,8 +203,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -226,7 +226,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -89,14 +89,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -115,10 +118,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -91,13 +91,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -118,7 +118,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -81,14 +81,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -107,10 +110,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -83,13 +83,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -110,7 +110,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -81,14 +81,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -107,10 +110,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -83,13 +83,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -110,7 +110,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -112,13 +112,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -139,7 +139,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -110,14 +110,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -136,10 +139,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -148,12 +148,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -170,13 +171,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -148,8 +148,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -171,7 +171,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -202,8 +202,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -225,7 +225,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -202,12 +202,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -224,13 +225,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -155,8 +155,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -178,7 +178,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -155,12 +155,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -177,13 +178,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -201,8 +201,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -224,7 +224,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -201,12 +201,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p eks -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-eks/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -223,13 +224,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -84,14 +84,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -110,10 +113,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -86,13 +86,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -113,7 +113,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -76,14 +76,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -102,10 +105,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -78,13 +78,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -105,7 +105,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -76,14 +76,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -102,10 +105,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -78,13 +78,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -105,7 +105,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -105,14 +105,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -131,10 +134,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -107,13 +107,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -134,7 +134,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -84,14 +84,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -110,10 +113,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -86,13 +86,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -113,7 +113,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -76,14 +76,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -102,10 +105,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -78,13 +78,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -105,7 +105,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -76,14 +76,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -102,10 +105,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -78,13 +78,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -105,7 +105,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -105,14 +105,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -131,10 +134,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -107,13 +107,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -134,7 +134,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -84,14 +84,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -110,10 +113,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -86,13 +86,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -113,7 +113,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -76,14 +76,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -102,10 +105,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -78,13 +78,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -105,7 +105,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -76,14 +76,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -102,10 +105,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -78,13 +78,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -105,7 +105,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -105,14 +105,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -131,10 +134,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -107,13 +107,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -134,7 +134,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -90,13 +90,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -117,7 +117,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -88,14 +88,17 @@ jobs:
       run: make k8sprovider
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -114,10 +117,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -80,14 +80,17 @@ jobs:
       run: make k8sprovider
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -106,10 +109,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -82,13 +82,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -109,7 +109,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -80,14 +80,17 @@ jobs:
       run: make k8sprovider
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -106,10 +109,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -82,13 +82,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -109,7 +109,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -109,14 +109,17 @@ jobs:
       run: make k8sprovider
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -135,10 +138,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -111,13 +111,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -138,7 +138,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
@@ -77,14 +77,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -103,10 +106,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
@@ -79,13 +79,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -106,7 +106,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
@@ -69,14 +69,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -95,10 +98,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
@@ -71,13 +71,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -98,7 +98,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
@@ -69,14 +69,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -95,10 +98,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
@@ -71,13 +71,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -98,7 +98,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -98,14 +98,17 @@ jobs:
       run: make generate_schema
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
-      run: >-
-        {
-          echo 'SCHEMA_CHANGES<<EOF';
-
-          schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json;
-
-          echo 'EOF';
-        } >> "$GITHUB_ENV"
+      id: schema-check
+      run: |
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
+        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+          echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
+        fi
+        cat >> schema-check-report.md <<'EOF'
+        <!-- "schemaCheck" -->
+        EOF
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
@@ -124,10 +127,8 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          ${{ env.SCHEMA_CHANGES }}
-          <!-- "schemaCheck" -->
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
+        body-path: schema-check-report.md
+    - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -100,13 +100,13 @@ jobs:
       name: Check Schema is Valid
       id: schema-check
       run: |
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > schema-check-report.md
-        if grep -Fq 'Looking good! No breaking changes found.' schema-check-report.md; then
+        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        if grep -Fq 'Looking good! No breaking changes found.' "$RUNNER_TEMP/schema-check-report.md"; then
           echo "no-breaking-changes=true" >> "$GITHUB_OUTPUT"
         else
           echo "no-breaking-changes=false" >> "$GITHUB_OUTPUT"
         fi
-        cat >> schema-check-report.md <<'EOF'
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
         <!-- "schemaCheck" -->
         EOF
       env:
@@ -127,7 +127,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
     - if: steps.schema-check.outputs.no-breaking-changes == 'true' &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -116,8 +116,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p pulumiservice -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-pulumiservice/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p pulumiservice -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-pulumiservice/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -139,7 +139,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/prerequisites.yml
@@ -116,12 +116,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p pulumiservice -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-pulumiservice/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p pulumiservice -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-pulumiservice/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -138,13 +139,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -131,8 +131,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -154,7 +154,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/prerequisites.yml
@@ -131,12 +131,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: inputs.acceptance_fanout == false && inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -153,13 +154,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
     - name: Upload artifacts
       uses: ./.github/actions/upload-prerequisites

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -192,8 +192,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json > schema-check-report.md
-        cat >> schema-check-report.md <<'EOF'
+        schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json > "$RUNNER_TEMP/schema-check-report.md"
+        cat >> "$RUNNER_TEMP/schema-check-report.md" <<'EOF'
 
         Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
 
@@ -215,7 +215,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body-path: schema-check-report.md
+        body-path: ${{ runner.temp }}/schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -192,12 +192,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        {
-          echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json;
-          echo "$EOF";
-        } >> "$GITHUB_ENV"
+        schema-tools compare -r github://api.github.com/pulumi -p xyz -o "${{ github.event.pull_request.base.ref }}" -n --local-path=provider/cmd/pulumi-resource-xyz/schema.json > schema-check-report.md
+        cat >> schema-check-report.md <<'EOF'
+
+        Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
+
+        <!-- "schemaCheck" -->
+        EOF
     - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
       name: Find schema check comment
       id: find-schema-check-comment
@@ -214,13 +215,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find-schema-check-comment.outputs.comment-id }}
         edit-mode: replace
-        body: >+
-          ${{ env.SCHEMA_CHANGES }}
-
-
-          Maintainer note: consult the [runbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-updating.md) for dealing with any breaking changes.
-
-          <!-- "schemaCheck" -->
+        body-path: schema-check-report.md
 
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||


### PR DESCRIPTION
## Summary

- write `schema-tools compare` output to a workspace file instead of `GITHUB_ENV`
- pass the schema report to the PR comment action with `body-path`
- preserve native providers' no-breaking-change label behavior with a small step output
- regenerate affected bridged and native provider fixtures

## Rationale

In [pulumi-aws#6551](https://github.com/pulumi/pulumi-aws/pull/6551), schema generation and validation succeeded, but the schema report was large enough that adding it to the job environment prevented subsequent Node actions from starting with `Argument list too long` ([failing job](https://github.com/pulumi/pulumi-aws/actions/runs/29762232303/job/88591384818)). Node post-actions failed for the same reason because the oversized environment persisted for the rest of the job.

The report was 139,772 bytes even though schema-tools' existing 500-change display cap was active. This change addresses the known failure boundary directly by keeping the report out of the process environment. It does not impose an additional report or comment size limit.

The same file-backed behavior is applied to the three bridged schema-comment paths and all four native schema-comment workflows.

## Testing

- `cd provider-ci && make clean && make all`
- `git diff --check`
