### PR TITLE
Pin actions/setup-node to v6

### DIFF
--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: actions/setup-node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
       - name: actions/setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -136,7 +136,7 @@ jobs:
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Nodejs }}#
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # we don't set node-version because we install with mise.
           # this step is needed to setup npm auth

--- a/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           environment: logins/pulumi-ci
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # we don't set node-version because we install with mise.
           # this step is needed to setup npm auth

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -177,7 +177,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -123,7 +123,7 @@ jobs:
           role-session-name: aws@githubActions
           role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # we don't set node-version because we install with mise.
           # this step is needed to setup npm auth

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
@@ -34,7 +34,7 @@ runs:
           *.sum
 
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/publish.yml
@@ -170,7 +170,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/xyz/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/publish.yml
@@ -167,7 +167,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
@@ -86,7 +86,7 @@ jobs:
             sdk/*.sum
             *.sum
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # we don't set node-version because we install with mise.
           # this step is needed to setup npm auth

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,6 +37,14 @@
       allowedVersions: "^6",
     },
     {
+      // v7 stopped exporting a placeholder NODE_AUTH_TOKEN alongside the
+      // .npmrc it writes. Yarn 1.x expands ${NODE_AUTH_TOKEN} eagerly and
+      // fails when the variable is unset, breaking Node SDK builds.
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["actions/setup-node"],
+      allowedVersions: "^6",
+    },
+    {
       // Until we get our change merged upstream, Renovate should track
       // pose/chores/better-stack-traces branch instead of main.
       // See: https://github.com/pulumi/ci-mgmt/issues/1987


### PR DESCRIPTION
Reverts the v7 bump and adds a Renovate pin so it is not re-proposed. actions/setup-node v7 no longer exports a placeholder `NODE_AUTH_TOKEN` alongside the `.npmrc` it writes; Yarn 1.x expands `${NODE_AUTH_TOKEN}` eagerly and fails when the variable is unset, so Node SDK builds cannot run.

Verified locally: `make clean && make all` passes and regeneration produces no changes beyond the revert.

Follow-up: the `Setup Node` step in the native `setup-tools` composite action exists only to write npm auth config, which build and test jobs do not need. Scoping it to the publish paths would remove the dependency on this pin.

Part of pulumi/home#4862
