### PR TITLE
fix(provider-ci): remove legacy Claude skills

### DIFF
--- a/provider-ci/internal/pkg/config_test.go
+++ b/provider-ci/internal/pkg/config_test.go
@@ -112,6 +112,62 @@ func TestGeneratePackageRendersOpenInspectSettings(t *testing.T) {
 	}
 }
 
+func TestGeneratePackageDeletesLegacyClaudeFiles(t *testing.T) {
+	outDir := t.TempDir()
+
+	config, err := loadDefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Provider = "aws"
+	config.ESC.Enabled = true
+
+	legacyFiles := []string{
+		".claude/CLAUDE.md",
+		".claude/skills/provider-code-review/SKILL.md",
+		".claude/skills/pulumi-upgrade-provider/SKILL.md",
+		".claude/skills/pulumi-upgrade-provider/references/upgrade-provider-errors.md",
+		".claude/skills/upstream-patches/SKILL.md",
+	}
+	for _, path := range legacyFiles {
+		fullPath := filepath.Join(outDir, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte("legacy generated file\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	unmanagedFile := ".claude/skills/provider-owned/SKILL.md"
+	fullUnmanagedPath := filepath.Join(outDir, unmanagedFile)
+	if err := os.MkdirAll(filepath.Dir(fullUnmanagedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullUnmanagedPath, []byte("provider-owned file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := GeneratePackage(GenerateOpts{
+		RepositoryName: "pulumi/pulumi-aws",
+		OutDir:         outDir,
+		TemplateName:   "bridged-provider",
+		Config:         config,
+		SkipMigrations: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range legacyFiles {
+		if _, err := os.Stat(filepath.Join(outDir, path)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be absent, got err %v", path, err)
+		}
+	}
+	if _, err := os.Stat(fullUnmanagedPath); err != nil {
+		t.Fatalf("expected %s to be preserved, got err %v", unmanagedFile, err)
+	}
+}
+
 func TestGeneratePackageDeletesLegacyAgenticWorkflowFiles(t *testing.T) {
 	outDir := t.TempDir()
 

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -156,6 +156,8 @@ func getDeletedFiles(templateName string) []string {
 			".github/workflows/claude.yml",
 			".claude/CLAUDE.md",
 			".claude/skills/provider-code-review",
+			".claude/skills/pulumi-upgrade-provider",
+			".claude/skills/upstream-patches",
 		}
 	case "external-bridged-provider":
 		return []string{


### PR DESCRIPTION
## Summary

- remove the legacy `pulumi-upgrade-provider` and `upstream-patches` Claude skills from managed bridged provider repositories
- add regression coverage for legacy Claude cleanup
- preserve unrelated provider-owned skills

Decided to go ahead and remove these now since we can add them back later from APM and pulumi/agent-skills. These ones are pretty old and out of date. Currently the plan is to `.gitignore` the centrally managed skills.

## Testing

- `cd provider-ci && make clean && make all`
- `git diff --check`
