### PR TITLE
Scope npm auth setup to the jobs that publish

### DIFF
--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: actions/setup-node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 
       - name: actions/setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -135,12 +135,6 @@ jobs:
 #{{ .Config.Actions.PreTest | toYaml | indent 6 }}#
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Nodejs }}#
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          # we don't set node-version because we install with mise.
-          # this step is needed to setup npm auth
-          registry-url: https://registry.npmjs.org
       - name: Verify nodejs release
         uses: #{{ .Config.ActionVersions.VerifyProviderRelease }}#
         with:
@@ -149,7 +143,6 @@ jobs:
           provider: #{{ .Config.Provider }}#
           providerVersion: ${{ inputs.providerVersion }}
         env:
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
 #{{ .Config | renderLocalEnv | indent 10 }}#
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Python }}#

--- a/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/build.yml
@@ -596,6 +596,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/prerelease.yml
@@ -556,6 +556,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml
@@ -558,6 +558,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws-native/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/aws-native/.github/workflows/build.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/build.yml
@@ -545,6 +545,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/prerelease.yml
@@ -501,6 +501,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/aws-native/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/release.yml
@@ -501,6 +501,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -106,12 +106,6 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
         with:
           environment: logins/pulumi-ci
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          # we don't set node-version because we install with mise.
-          # this step is needed to setup npm auth
-          registry-url: https://registry.npmjs.org
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -120,7 +114,6 @@ jobs:
           provider: aws
           providerVersion: ${{ inputs.providerVersion }}
         env:
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OIDC_ROLE_ARN: ${{ steps.esc-secrets.outputs.OIDC_ROLE_ARN }}
       - name: Verify python release

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/command/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/command/.github/workflows/build.yml
+++ b/provider-ci/test-providers/command/.github/workflows/build.yml
@@ -478,6 +478,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/command/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/command/.github/workflows/prerelease.yml
@@ -434,6 +434,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/command/.github/workflows/release.yml
+++ b/provider-ci/test-providers/command/.github/workflows/release.yml
@@ -434,6 +434,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker-build/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/docker-build/.github/workflows/build.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/build.yml
@@ -557,6 +557,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/prerelease.yml
@@ -513,6 +513,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/docker-build/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/release.yml
@@ -513,6 +513,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -177,7 +177,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -122,12 +122,6 @@ jobs:
           role-duration-seconds: 7200
           role-session-name: aws@githubActions
           role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          # we don't set node-version because we install with mise.
-          # this step is needed to setup npm auth
-          registry-url: https://registry.npmjs.org
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -136,7 +130,6 @@ jobs:
           provider: eks
           providerVersion: ${{ inputs.providerVersion }}
         env:
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
           PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/build.yml
@@ -526,6 +526,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/prerelease.yml
@@ -482,6 +482,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/release.yml
@@ -482,6 +482,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/build.yml
@@ -526,6 +526,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/prerelease.yml
@@ -482,6 +482,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/release.yml
@@ -482,6 +482,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/build.yml
@@ -527,6 +527,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/prerelease.yml
@@ -483,6 +483,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/release.yml
@@ -483,6 +483,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/kubernetes/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/build.yml
@@ -552,6 +552,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/prerelease.yml
@@ -508,6 +508,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/release.yml
@@ -508,6 +508,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/actions/setup-tools/action.yml
@@ -32,10 +32,3 @@ runs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
-
-    - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-      with:
-        # we don't set node-version because we install with mise.
-        # this step is needed to setup npm auth
-        registry-url: https://registry.npmjs.org

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/build.yml
@@ -514,6 +514,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/prerelease.yml
@@ -470,6 +470,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/release.yml
@@ -470,6 +470,12 @@ jobs:
         ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install twine==5.0.0
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        # we don't set node-version because we install with mise.
+        # this step is needed to setup npm auth
+        registry-url: https://registry.npmjs.org
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/publish.yml
@@ -170,7 +170,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/xyz/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/publish.yml
@@ -167,7 +167,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/verify-release.yml
@@ -85,12 +85,6 @@ jobs:
             sdk/go/*.sum
             sdk/*.sum
             *.sum
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          # we don't set node-version because we install with mise.
-          # this step is needed to setup npm auth
-          registry-url: https://registry.npmjs.org
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -99,5 +93,4 @@ jobs:
           provider: xyz
           providerVersion: ${{ inputs.providerVersion }}
         env:
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,14 +37,6 @@
       allowedVersions: "^6",
     },
     {
-      // v7 stopped exporting a placeholder NODE_AUTH_TOKEN alongside the
-      // .npmrc it writes. Yarn 1.x expands ${NODE_AUTH_TOKEN} eagerly and
-      // fails when the variable is unset, breaking Node SDK builds.
-      matchManagers: ["github-actions"],
-      matchPackageNames: ["actions/setup-node"],
-      allowedVersions: "^6",
-    },
-    {
       // Until we get our change merged upstream, Renovate should track
       // pose/chores/better-stack-traces branch instead of main.
       // See: https://github.com/pulumi/ci-mgmt/issues/1987


### PR DESCRIPTION
`setup-node` writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}`, but the native `setup-tools` composite ran it in every job while only `publish_sdk` supplies the token. Moves it to the `publish_sdk` jobs, matching the pattern `base/publish.yml` already uses, and drops it from release verification, which only installs an already-published public package.

With auth scoped to the jobs that authenticate, v7 is safe, so this restores it and removes the Renovate pin.

Part of pulumi/home#4862


## Verification against real providers

Generated provider PRs directly from this branch (`gh workflow run update-workflows-single-bridged-provider.yml --ref pose/scope-npm-auth-to-publish`), so their CI runs these templates with `actions/setup-node` back on v7. All green, no failed or cancelled checks:

| Provider | Type | PR | nodejs SDK build |
| --- | --- | --- | --- |
| pulumi-command | native | pulumi/pulumi-command#1352 | `build_sdks (nodejs)` success |
| pulumi-docker-build | native | pulumi/pulumi-docker-build#960 | `build_sdks (nodejs)` success |
| pulumi-aws-native | native | pulumi/pulumi-aws-native#3095 | `build_sdks (nodejs)` success |
| pulumi-cloudflare | bridged | pulumi/pulumi-cloudflare#1641 | `build_sdk (nodejs)` success |

All four reached `Sentinel` success. The three native repos exercise the `setup-tools` composite change on the job that was failing; cloudflare covers the bridged `publish.yml` and `verify-release.yml` edits.

These PRs were opened for verification only and closed afterwards, they are not intended to merge.

Coverage note: these runs exercise the removal from the `setup-tools` composite, which is the path that was failing. They do not exercise the `Setup Node` step added to `publish_sdk`, since that job only runs on push and tag events, never on pull requests. That step is copied verbatim from the equivalent in `base/publish.yml`, and `build.yml` publishes dev-tagged SDKs on every master push, so it will be exercised on the first merge after rollout rather than first at release time.

Note that the `downstream` job on this PR is not evidence in either direction, see #2416.
