### PR TITLE
[POC] Split acceptance tests by SDK artifact dependency

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -5,7 +5,10 @@ import (
 	_ "embed" // For embedding action versions.
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -125,6 +128,11 @@ type Config struct {
 	// IntegrationTestProvider will run e2e tests in the provider as well as in
 	// the examples directory when set to true. Defaults to false.
 	IntegrationTestProvider bool `yaml:"integrationTestProvider"`
+
+	// AcceptanceTestSuites partitions acceptance tests by artifact dependency.
+	// Each suite is independently sharded from one file or directory under
+	// TestFolder. When configured, this replaces the legacy Shards test job.
+	AcceptanceTestSuites []acceptanceTestSuite `yaml:"acceptanceTestSuites"`
 
 	// TestPulumiExamples runs e2e tests using the examples and test suite in
 	// the pulumi/examples repo when set to true. Defaults to false. This is
@@ -415,7 +423,83 @@ func LoadLocalConfig(path string) (Config, error) {
 		config.ModulePath = "provider"
 	}
 
+	if err := validateAcceptanceTestSuites(config); err != nil {
+		return Config{}, err
+	}
+
 	return config, nil
+}
+
+var (
+	acceptanceTestSuiteNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	acceptanceTestSuiteRootPattern = regexp.MustCompile(`^[A-Za-z0-9._/+\-]+$`)
+)
+
+type acceptanceTestSuite struct {
+	// Name identifies the suite in generated GitHub Actions job IDs.
+	Name string `yaml:"name"`
+	// Root is a file or directory relative to Config.TestFolder from which
+	// pulumi/shard discovers this suite's tests.
+	Root string `yaml:"root"`
+	// Shards is the number of jobs across which the suite is distributed.
+	Shards int `yaml:"shards"`
+	// RequiresSDKs must be set explicitly. SDK-dependent suites download and
+	// install every configured generated SDK before running tests.
+	RequiresSDKs *bool `yaml:"requiresSDKs"`
+}
+
+// NeedsSDKs exposes the explicitly configured SDK requirement to templates.
+func (s acceptanceTestSuite) NeedsSDKs() bool {
+	return s.RequiresSDKs != nil && *s.RequiresSDKs
+}
+
+func validateAcceptanceTestSuites(config Config) error {
+	if len(config.AcceptanceTestSuites) == 0 {
+		return nil
+	}
+	if config.Shards != 0 {
+		return fmt.Errorf("acceptanceTestSuites cannot be used with shards")
+	}
+
+	names := map[string]struct{}{}
+	roots := make([]string, 0, len(config.AcceptanceTestSuites))
+	for i, suite := range config.AcceptanceTestSuites {
+		prefix := fmt.Sprintf("acceptanceTestSuites[%d]", i)
+		if !acceptanceTestSuiteNamePattern.MatchString(suite.Name) {
+			return fmt.Errorf("%s.name must match %s", prefix, acceptanceTestSuiteNamePattern)
+		}
+		if _, exists := names[suite.Name]; exists {
+			return fmt.Errorf("%s.name %q is duplicated", prefix, suite.Name)
+		}
+		names[suite.Name] = struct{}{}
+
+		if suite.Root == "" {
+			return fmt.Errorf("%s.root is required", prefix)
+		}
+		cleanRoot := path.Clean(suite.Root)
+		if cleanRoot != suite.Root || path.IsAbs(cleanRoot) || cleanRoot == ".." ||
+			strings.HasPrefix(cleanRoot, "../") || !acceptanceTestSuiteRootPattern.MatchString(cleanRoot) {
+			return fmt.Errorf("%s.root %q must be a clean, shell-safe relative path under test-folder", prefix, suite.Root)
+		}
+		for _, otherRoot := range roots {
+			if cleanRoot == otherRoot || cleanRoot == "." || otherRoot == "." ||
+				strings.HasPrefix(cleanRoot, otherRoot+"/") || strings.HasPrefix(otherRoot, cleanRoot+"/") {
+				return fmt.Errorf("%s.root %q overlaps another suite root %q", prefix, suite.Root, otherRoot)
+			}
+		}
+		roots = append(roots, cleanRoot)
+
+		if suite.Shards < 1 {
+			return fmt.Errorf("%s.shards must be greater than zero", prefix)
+		}
+		if suite.RequiresSDKs == nil {
+			return fmt.Errorf("%s.requiresSDKs must be set explicitly", prefix)
+		}
+		if suite.NeedsSDKs() && config.NoSchema {
+			return fmt.Errorf("%s cannot require SDKs when noSchema is true", prefix)
+		}
+	}
+	return nil
 }
 
 type GitHubApp struct {

--- a/provider-ci/internal/pkg/config_test.go
+++ b/provider-ci/internal/pkg/config_test.go
@@ -211,6 +211,258 @@ func TestGeneratePackageDeletesLegacyProviderPrefixedAgenticWorkflows(t *testing
 	}
 }
 
+func TestLoadLocalConfigValidatesAcceptanceTestSuites(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "valid",
+			config: `provider: aws
+acceptanceTestSuites:
+  - name: provider
+    root: provider-tests
+    shards: 4
+    requiresSDKs: false
+  - name: sdk
+    root: sdk-smoke
+    shards: 2
+    requiresSDKs: true
+`,
+		},
+		{
+			name: "legacy shards conflict",
+			config: `provider: aws
+shards: 8
+acceptanceTestSuites:
+  - name: provider
+    root: provider-tests
+    shards: 4
+    requiresSDKs: false
+`,
+			wantErr: "acceptanceTestSuites cannot be used with shards",
+		},
+		{
+			name: "SDK requirement omitted",
+			config: `provider: aws
+acceptanceTestSuites:
+  - name: provider
+    root: provider-tests
+    shards: 4
+`,
+			wantErr: "requiresSDKs must be set explicitly",
+		},
+		{
+			name: "overlapping roots",
+			config: `provider: aws
+acceptanceTestSuites:
+  - name: all
+    root: tests
+    shards: 4
+    requiresSDKs: false
+  - name: sdk
+    root: tests/sdk
+    shards: 2
+    requiresSDKs: true
+`,
+			wantErr: "overlaps another suite root",
+		},
+		{
+			name: "invalid job name",
+			config: `provider: aws
+acceptanceTestSuites:
+  - name: SDK_Smoke
+    root: sdk-smoke
+    shards: 2
+    requiresSDKs: true
+`,
+			wantErr: "name must match",
+		},
+		{
+			name: "shell-unsafe root",
+			config: `provider: aws
+acceptanceTestSuites:
+  - name: sdk
+    root: sdk$(touch-bad)
+    shards: 2
+    requiresSDKs: true
+`,
+			wantErr: "shell-safe relative path",
+		},
+		{
+			name: "SDKs unavailable",
+			config: `provider: aws
+noSchema: true
+acceptanceTestSuites:
+  - name: sdk
+    root: sdk-smoke
+    shards: 2
+    requiresSDKs: true
+`,
+			wantErr: "cannot require SDKs when noSchema is true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), ".ci-mgmt.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			config, err := LoadLocalConfig(configPath)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(config.AcceptanceTestSuites) != 2 || config.AcceptanceTestSuites[0].NeedsSDKs() ||
+					!config.AcceptanceTestSuites[1].NeedsSDKs() {
+					t.Fatalf("unexpected suites: %#v", config.AcceptanceTestSuites)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestGeneratePackagePartitionsAcceptanceTestSuites(t *testing.T) {
+	outDir := t.TempDir()
+
+	config, err := loadDefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Provider = "aws"
+	config.ESC.Enabled = true
+	config.GenerateNightlyTestWorkflow = true
+	requiresSDKs := true
+	doesNotRequireSDKs := false
+	config.AcceptanceTestSuites = []acceptanceTestSuite{
+		{Name: "provider", Root: "provider-tests", Shards: 4, RequiresSDKs: &doesNotRequireSDKs},
+		{Name: "sdk", Root: "sdk-smoke", Shards: 2, RequiresSDKs: &requiresSDKs},
+	}
+
+	if err := GeneratePackage(GenerateOpts{
+		RepositoryName: "pulumi/pulumi-aws",
+		OutDir:         outDir,
+		TemplateName:   "bridged-provider",
+		Config:         config,
+		SkipMigrations: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	readWorkflow := func(name string) string {
+		t.Helper()
+		workflow, err := os.ReadFile(filepath.Join(outDir, ".github", "workflows", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(workflow)
+	}
+
+	testWorkflow := readWorkflow("test.yml")
+	for _, want := range []string{
+		"suite_root:\n",
+		"if: inputs.requires_sdks\n",
+		"SUITE_ROOT: ${{ inputs.suite_root }}",
+		`--root "$SUITE_ROOT"`,
+		"current-shard: ${{ fromJSON(inputs.shard_indices) }}",
+	} {
+		if !strings.Contains(testWorkflow, want) {
+			t.Errorf("test workflow does not contain %q", want)
+		}
+	}
+
+	for _, name := range []string{"run-acceptance-tests.yml", "master.yml", "nightly-test.yml", "prerelease.yml", "release.yml"} {
+		workflow := readWorkflow(name)
+		if !strings.Contains(workflow, "  acceptance_provider:\n") || !strings.Contains(workflow, "  acceptance_sdk:\n") {
+			t.Errorf("%s does not call both configured suites", name)
+		}
+		providerStart := strings.Index(workflow, "  acceptance_provider:\n")
+		sdkStart := strings.Index(workflow, "  acceptance_sdk:\n")
+		providerJob := workflow[providerStart:sdkStart]
+		if strings.Contains(providerJob, "      - build_sdk\n") {
+			t.Errorf("%s makes the provider-only suite wait for build_sdk", name)
+		}
+		sdkJob := workflow[sdkStart:]
+		if !strings.Contains(sdkJob, "      - build_sdk\n") {
+			t.Errorf("%s does not make the SDK suite wait for build_sdk", name)
+		}
+	}
+
+	acceptanceWorkflow := readWorkflow("run-acceptance-tests.yml")
+	if !strings.Contains(acceptanceWorkflow, "    - acceptance_provider\n    - acceptance_sdk\n    - build_sdk\n") {
+		t.Errorf("acceptance sentinel does not require every suite and the SDK build")
+	}
+}
+
+func TestGeneratePackageRejectsAcceptanceTestSuitesForNativeTemplates(t *testing.T) {
+	requiresSDKs := false
+	config := Config{
+		AcceptanceTestSuites: []acceptanceTestSuite{
+			{Name: "provider", Root: ".", Shards: 1, RequiresSDKs: &requiresSDKs},
+		},
+	}
+
+	for _, templateName := range []string{"native", "external-native-provider"} {
+		t.Run(templateName, func(t *testing.T) {
+			err := GeneratePackage(GenerateOpts{
+				OutDir:       t.TempDir(),
+				TemplateName: templateName,
+				Config:       config,
+			})
+			if err == nil || !strings.Contains(err.Error(), "not supported by native workflow templates") {
+				t.Fatalf("expected native template error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGeneratePackagePreservesLegacyShardedTestWorkflow(t *testing.T) {
+	outDir := t.TempDir()
+
+	config, err := loadDefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Provider = "aws"
+	config.ESC.Enabled = true
+	config.Shards = 8
+
+	if err := GeneratePackage(GenerateOpts{
+		RepositoryName: "pulumi/pulumi-aws",
+		OutDir:         outDir,
+		TemplateName:   "bridged-provider",
+		Config:         config,
+		SkipMigrations: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	testWorkflow, err := os.ReadFile(filepath.Join(outDir, ".github", "workflows", "test.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(testWorkflow), "suite_root") {
+		t.Fatal("legacy test workflow unexpectedly contains suite inputs")
+	}
+
+	acceptanceWorkflow, err := os.ReadFile(filepath.Join(outDir, ".github", "workflows", "run-acceptance-tests.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"  test:\n", "    - test\n", "      - build_sdk\n"} {
+		if !strings.Contains(string(acceptanceWorkflow), want) {
+			t.Errorf("legacy acceptance workflow does not contain %q", want)
+		}
+	}
+}
+
 func TestGeneratePackageUsesUpgradeProviderRunner(t *testing.T) {
 	outDir := t.TempDir()
 

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -52,9 +52,17 @@ func DefaultGenName(templateName string) string {
 }
 
 func GeneratePackage(opts GenerateOpts) error {
+	if err := validateAcceptanceTestSuites(opts.Config); err != nil {
+		return fmt.Errorf("invalid acceptance test suites: %w", err)
+	}
+
 	templateDirs, err := getTemplateDirs(opts.TemplateName)
 	if err != nil {
 		return fmt.Errorf("error getting template directories: %w", err)
+	}
+	if len(opts.Config.AcceptanceTestSuites) > 0 &&
+		(opts.TemplateName == "native" || opts.TemplateName == "external-native-provider") {
+		return fmt.Errorf("acceptanceTestSuites is not supported by native workflow templates")
 	}
 
 	// GenName defaults to "tfgen" for bridged providers and "gen" for others

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/main.yml
@@ -87,7 +87,16 @@ jobs:
     needs:
       - prerequisites
       - build_provider
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- if not .Config.NoSchema }}#
+      - build_sdk
+#{{- end }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+      - acceptance_#{{ $suite.Name }}#
+#{{- end }}#
+#{{- else }}#
       - test
+#{{- end }}#
       - license_check
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -124,6 +133,31 @@ jobs:
         RELEASE_BOT_KEY: ${{ steps.esc-secrets.outputs.RELEASE_BOT_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+
+  acceptance_#{{ $suite.Name }}#:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+#{{- if $suite.NeedsSDKs }}#
+      - build_sdk
+#{{- end }}#
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: #{{ $suite.Root | quote }}#
+      shard_count: #{{ $suite.Shards }}#
+      shard_indices: '#{{ until $suite.Shards | toJson }}#'
+      requires_sdks: #{{ $suite.NeedsSDKs }}#
+
+#{{- end }}#
+#{{- else }}#
+
   test:
     uses: ./.github/workflows/test.yml
     needs:
@@ -138,6 +172,8 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+
+#{{- end }}#
 
 name: #{{ .Config.ProviderDefaultBranch }}#
 on:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/nightly-test.yml
@@ -40,6 +40,31 @@ jobs:
       version: ${{ needs.prerequisites.outputs.version }}
   #{{- end }}#
 
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+
+  acceptance_#{{ $suite.Name }}#:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+#{{- if $suite.NeedsSDKs }}#
+      - build_sdk
+#{{- end }}#
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: #{{ $suite.Root | quote }}#
+      shard_count: #{{ $suite.Shards }}#
+      shard_indices: '#{{ until $suite.Shards | toJson }}#'
+      requires_sdks: #{{ $suite.NeedsSDKs }}#
+
+#{{- end }}#
+#{{- else }}#
+
   test:
     uses: ./.github/workflows/test.yml
     needs:
@@ -54,6 +79,8 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+
+#{{- end }}#
 
 name: cron
 on:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerelease.yml
@@ -61,7 +61,16 @@ jobs:
     needs:
       - prerequisites
       - build_provider
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- if not .Config.NoSchema }}#
+      - build_sdk
+#{{- end }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+      - acceptance_#{{ $suite.Name }}#
+#{{- end }}#
+#{{- else }}#
       - test
+#{{- end }}#
       - license_check
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -69,6 +78,31 @@ jobs:
       version: ${{ needs.prerequisites.outputs.version }}
       isPrerelease: true
       setLatestRelease: false
+
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+
+  acceptance_#{{ $suite.Name }}#:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+#{{- if $suite.NeedsSDKs }}#
+      - build_sdk
+#{{- end }}#
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: #{{ $suite.Root | quote }}#
+      shard_count: #{{ $suite.Shards }}#
+      shard_indices: '#{{ until $suite.Shards | toJson }}#'
+      requires_sdks: #{{ $suite.NeedsSDKs }}#
+
+#{{- end }}#
+#{{- else }}#
 
   test:
     uses: ./.github/workflows/test.yml
@@ -84,6 +118,8 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+
+#{{- end }}#
 
 name: prerelease
 on:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/release.yml
@@ -69,7 +69,16 @@ jobs:
     needs:
       - prerequisites
       - build_provider
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- if not .Config.NoSchema }}#
+      - build_sdk
+#{{- end }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+      - acceptance_#{{ $suite.Name }}#
+#{{- end }}#
+#{{- else }}#
       - test
+#{{- end }}#
       - license_check
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -78,6 +87,31 @@ jobs:
       isPrerelease: false
       # Only tags on the default branch should set the release as `latest`; backported releases (tagged on a feature branch) should not.
       setLatestRelease: ${{ github.event.base_ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+
+  acceptance_#{{ $suite.Name }}#:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+#{{- if $suite.NeedsSDKs }}#
+      - build_sdk
+#{{- end }}#
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: #{{ $suite.Root | quote }}#
+      shard_count: #{{ $suite.Shards }}#
+      shard_indices: '#{{ until $suite.Shards | toJson }}#'
+      requires_sdks: #{{ $suite.NeedsSDKs }}#
+
+#{{- end }}#
+#{{- else }}#
 
   test:
     uses: ./.github/workflows/test.yml
@@ -93,3 +127,4 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+#{{- end }}#

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -331,7 +331,16 @@ jobs:
     permissions:
       statuses: write
     needs:
+    #{{- if .Config.AcceptanceTestSuites }}#
+    #{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+    - acceptance_#{{ $suite.Name }}#
+    #{{- end }}#
+    #{{- if not .Config.NoSchema }}#
+    - build_sdk
+    #{{- end }}#
+    #{{- else }}#
     - test
+    #{{- end }}#
     - build_provider
     #{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
     - build_schema
@@ -355,6 +364,34 @@ jobs:
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- range $_, $suite := .Config.AcceptanceTestSuites }}#
+
+  acceptance_#{{ $suite.Name }}#:
+    # Don't run tests on PRs from forks.
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+#{{- if $suite.NeedsSDKs }}#
+      - build_sdk
+#{{- end }}#
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: #{{ $suite.Root | quote }}#
+      shard_count: #{{ $suite.Shards }}#
+      shard_indices: '#{{ until $suite.Shards | toJson }}#'
+      requires_sdks: #{{ $suite.NeedsSDKs }}#
+
+#{{- end }}#
+#{{- else }}#
+
   test:
     # Don't run tests on PRs from forks.
     if: github.event_name == 'repository_dispatch' ||
@@ -372,6 +409,8 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+
+#{{- end }}#
 
   license_check:
     name: License Check

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -9,6 +9,24 @@ on:
          required: true
          type: string
          description: Version of the provider to test
+#{{- if .Config.AcceptanceTestSuites }}#
+       suite_root:
+         required: true
+         type: string
+         description: File or directory under test-folder from which to discover tests
+       shard_count:
+         required: true
+         type: number
+         description: Total number of shards in this suite
+       shard_indices:
+         required: true
+         type: string
+         description: JSON array containing the zero-based shard indices
+       requires_sdks:
+         required: true
+         type: boolean
+         description: Whether this suite consumes generated SDK artifacts
+#{{- end }}#
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
@@ -52,6 +70,7 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 #{{- end }}#
+#{{- if not .Config.AcceptanceTestSuites }}#
     - name: Checkout p/examples
       #{{- if not .Config.Shards }}#
       if: matrix.testTarget == 'pulumiExamples'
@@ -60,6 +79,7 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
+#{{- end }}#
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -76,6 +96,20 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Download bin
       uses: ./.github/actions/download-provider
+#{{- if .Config.AcceptanceTestSuites }}#
+    #{{- if not .Config.NoSchema }}#
+    #{{- range $_, $language := .Config.Languages }}#
+    - name: Download #{{ $language }}# SDK
+      if: inputs.requires_sdks
+      uses: ./.github/actions/download-sdk
+      with:
+        language: #{{ $language }}#
+    #{{- end }}#
+    - name: Restore makefile progress
+      if: inputs.requires_sdks
+      run: make --touch provider schema build_sdks
+    #{{- end }}#
+#{{- else }}#
     #{{- if not .Config.Shards }}#
     - name: Setup Go Cache
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
@@ -107,11 +141,14 @@ jobs:
       run: make --touch provider schema build_sdks
 #{{- end }}#
     #{{- end }}#
+#{{- end }}#
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     #{{- if not .Config.NoSchema }}#
     - name: Install Python deps
-    #{{- if not .Config.Shards }}#
+    #{{- if .Config.AcceptanceTestSuites }}#
+      if: inputs.requires_sdks
+    #{{- else if not .Config.Shards }}#
       if: matrix.language == 'python'
     #{{- end }}#
       run: |-
@@ -159,11 +196,34 @@ jobs:
     - name: Run setup script
       run: #{{ index .Config.SetupScript }}#
     #{{- end }}#
-#{{- if and .Config.Shards (not .Config.NoSchema) }}#
+#{{- if and .Config.AcceptanceTestSuites (not .Config.NoSchema) }}#
+    - name: Install prebuilt SDKs
+      if: inputs.requires_sdks
+      run: make install_sdks
+#{{- else if and .Config.Shards (not .Config.NoSchema) }}#
     - name: Install prebuilt SDKs
       run: make install_sdks
 #{{- end }}#
-#{{- if not .Config.Shards }}#
+#{{- if .Config.AcceptanceTestSuites }}#
+#{{- if .Config.Actions.PreTest }}#
+#{{ .Config.Actions.PreTest | toYaml | indent 4 }}#
+#{{- end }}#
+    - name: Generate test shards
+      env:
+        SUITE_ROOT: ${{ inputs.suite_root }}
+      run: |-
+        cd #{{ .Config.TestFolder }}#
+        go run github.com/pulumi/shard@861c9ce4aa851e98c19f8376892bf7e47238fa1b \
+            --root "$SUITE_ROOT" \
+            --total ${{ inputs.shard_count }} \
+            --index ${{ matrix.current-shard }} \
+            --output env >> "$GITHUB_ENV"
+    - name: Run tests
+      run: |
+        make GOTESTARGS="-test.run ${SHARD_TESTS} ${SHARD_PATHS}" test
+      env:
+#{{ .Config | renderLocalEnv | indent 8 }}#
+#{{- else if not .Config.Shards }}#
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
 #{{- if .Config.Actions.PreTest }}#
@@ -205,7 +265,10 @@ jobs:
 #{{- end }}#
     strategy:
       fail-fast: false
-#{{- if .Config.Shards }}#
+#{{- if .Config.AcceptanceTestSuites }}#
+      matrix:
+        current-shard: ${{ fromJSON(inputs.shard_indices) }}
+#{{- else if .Config.Shards }}#
       matrix:
         total-shards:
           - #{{ .Config.Shards }}#

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -124,8 +124,27 @@ integrationTestProvider: false
 # This is unused: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22testPulumiExamples%3A%22&type=code
 testPulumiExamples: false
 
-# How many shared to execute integration tests with. If omitted, shard behavior defaults to language-based sharding.
+# How many shards to execute integration tests with. If omitted, shard behavior defaults to language-based sharding.
+# This legacy option cannot be combined with acceptanceTestSuites.
 shards: 0
+
+# Optionally partition acceptance tests into independently sharded suites according to whether they consume
+# generated SDK artifacts. Suite roots may be files or directories and are shell-safe paths relative to test-folder.
+# Roots must not overlap, so no top-level test is selected by more than one suite; providers remain responsible for
+# covering every intended test. Each root must declare at least as many top-level tests as its shard count; pulumi/shard
+# does not support empty shards for arbitrary roots. requiresSDKs is mandatory. File roots filter which tests run, but
+# Go still compiles sibling files in the package and runs package initialization/TestMain; use separate directories or
+# packages when generated SDKs affect compilation or setup. When configured, these suites replace the legacy
+# language/shards test job in every generated workflow.
+#acceptanceTestSuites:
+#  - name: provider
+#    root: provider-tests
+#    shards: 4
+#    requiresSDKs: false
+#  - name: sdk
+#    root: sdk-smoke
+#    shards: 2
+#    requiresSDKs: true
 
 # runner defines the runs-on property for various stages of the build
 # These are not overridden by any providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22runner%3A%22&type=code

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -3,7 +3,15 @@ disableMajorProviderUpgrades: true
 lint: false
 major-version: 7
 parallel: 1
-shards: 8
+acceptanceTestSuites:
+    - name: yaml
+      root: examples_yaml_test.go
+      shards: 8
+      requiresSDKs: false
+    - name: sdk
+      root: examples_test.go
+      shards: 2
+      requiresSDKs: true
 timeout: 150
 generate-nightly-test-workflow: true
 providerVersion: github.com/hashicorp/terraform-provider-aws/version.ProviderVersion

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -84,7 +84,9 @@ jobs:
     needs:
       - prerequisites
       - build_provider
-      - test
+      - build_sdk
+      - acceptance_yaml
+      - acceptance_sdk
       - license_check
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -129,7 +131,23 @@ jobs:
         RELEASE_BOT_KEY: ${{ steps.esc-secrets.outputs.RELEASE_BOT_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  test:
+  acceptance_yaml:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_yaml_test.go"
+      shard_count: 8
+      shard_indices: '[0,1,2,3,4,5,6,7]'
+      requires_sdks: false
+
+  acceptance_sdk:
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites
@@ -141,6 +159,10 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_test.go"
+      shard_count: 2
+      shard_indices: '[0,1]'
+      requires_sdks: true
 
 name: master
 on:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -43,7 +43,23 @@ jobs:
     with:
       version: ${{ needs.prerequisites.outputs.version }}
 
-  test:
+  acceptance_yaml:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_yaml_test.go"
+      shard_count: 8
+      shard_indices: '[0,1,2,3,4,5,6,7]'
+      requires_sdks: false
+
+  acceptance_sdk:
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites
@@ -55,6 +71,10 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_test.go"
+      shard_count: 2
+      shard_indices: '[0,1]'
+      requires_sdks: true
 
 name: cron
 on:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -58,7 +58,9 @@ jobs:
     needs:
       - prerequisites
       - build_provider
-      - test
+      - build_sdk
+      - acceptance_yaml
+      - acceptance_sdk
       - license_check
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -67,7 +69,23 @@ jobs:
       isPrerelease: true
       setLatestRelease: false
 
-  test:
+  acceptance_yaml:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_yaml_test.go"
+      shard_count: 8
+      shard_indices: '[0,1,2,3,4,5,6,7]'
+      requires_sdks: false
+
+  acceptance_sdk:
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites
@@ -79,6 +97,10 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_test.go"
+      shard_count: 2
+      shard_indices: '[0,1]'
+      requires_sdks: true
 
 name: prerelease
 on:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -63,7 +63,9 @@ jobs:
     needs:
       - prerequisites
       - build_provider
-      - test
+      - build_sdk
+      - acceptance_yaml
+      - acceptance_sdk
       - license_check
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -73,7 +75,23 @@ jobs:
       # Only tags on the default branch should set the release as `latest`; backported releases (tagged on a feature branch) should not.
       setLatestRelease: ${{ github.event.base_ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
-  test:
+  acceptance_yaml:
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_yaml_test.go"
+      shard_count: 8
+      shard_indices: '[0,1,2,3,4,5,6,7]'
+      requires_sdks: false
+
+  acceptance_sdk:
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites
@@ -85,3 +103,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_test.go"
+      shard_count: 2
+      shard_indices: '[0,1]'
+      requires_sdks: true

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -288,7 +288,9 @@ jobs:
     permissions:
       statuses: write
     needs:
-    - test
+    - acceptance_yaml
+    - acceptance_sdk
+    - build_sdk
     - build_provider
     - build_schema
     - test_provider
@@ -307,7 +309,26 @@ jobs:
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  test:
+  acceptance_yaml:
+    # Don't run tests on PRs from forks.
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/test.yml
+    needs:
+      - prerequisites
+      - build_provider
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_yaml_test.go"
+      shard_count: 8
+      shard_indices: '[0,1,2,3,4,5,6,7]'
+      requires_sdks: false
+
+  acceptance_sdk:
     # Don't run tests on PRs from forks.
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -322,6 +343,10 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      suite_root: "examples_test.go"
+      shard_count: 2
+      shard_indices: '[0,1]'
+      requires_sdks: true
 
   license_check:
     name: License Check

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -9,6 +9,22 @@ on:
          required: true
          type: string
          description: Version of the provider to test
+       suite_root:
+         required: true
+         type: string
+         description: File or directory under test-folder from which to discover tests
+       shard_count:
+         required: true
+         type: number
+         description: Total number of shards in this suite
+       shard_indices:
+         required: true
+         type: string
+         description: JSON array containing the zero-based shard indices
+       requires_sdks:
+         required: true
+         type: boolean
+         description: Whether this suite consumes generated SDK artifacts
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
@@ -60,11 +76,6 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - name: Checkout p/examples
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: pulumi/examples
-        path: p-examples
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -82,30 +93,37 @@ jobs:
     - name: Download bin
       uses: ./.github/actions/download-provider
     - name: Download nodejs SDK
+      if: inputs.requires_sdks
       uses: ./.github/actions/download-sdk
       with:
         language: nodejs
     - name: Download python SDK
+      if: inputs.requires_sdks
       uses: ./.github/actions/download-sdk
       with:
         language: python
     - name: Download dotnet SDK
+      if: inputs.requires_sdks
       uses: ./.github/actions/download-sdk
       with:
         language: dotnet
     - name: Download go SDK
+      if: inputs.requires_sdks
       uses: ./.github/actions/download-sdk
       with:
         language: go
     - name: Download java SDK
+      if: inputs.requires_sdks
       uses: ./.github/actions/download-sdk
       with:
         language: java
     - name: Restore makefile progress
+      if: inputs.requires_sdks
       run: make --touch provider schema build_sdks
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
+      if: inputs.requires_sdks
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
@@ -123,12 +141,16 @@ jobs:
       with:
         environment: logins/pulumi-ci
     - name: Install prebuilt SDKs
+      if: inputs.requires_sdks
       run: make install_sdks
     - name: Generate test shards
+      env:
+        SUITE_ROOT: ${{ inputs.suite_root }}
       run: |-
         cd examples
         go run github.com/pulumi/shard@861c9ce4aa851e98c19f8376892bf7e47238fa1b \
-            --total ${{ matrix.total-shards }} \
+            --root "$SUITE_ROOT" \
+            --total ${{ inputs.shard_count }} \
             --index ${{ matrix.current-shard }} \
             --output env >> "$GITHUB_ENV"
     - name: Run tests
@@ -140,14 +162,4 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        total-shards:
-          - 8
-        current-shard:
-          - 0
-          - 1
-          - 2
-          - 3
-          - 4
-          - 5
-          - 6
-          - 7
+        current-shard: ${{ fromJSON(inputs.shard_indices) }}


### PR DESCRIPTION
> [!IMPORTANT]
> **POC:** This draft is intended to validate the configuration model and
> generated workflow graph. It is not ready for provider rollout as-is.

Generated acceptance tests currently use one reusable `test.yml` job. Sharded
providers therefore wait for every generated SDK build before any acceptance
test starts, even when part of the suite only needs the provider binary and
Pulumi CLI.

This POC adds an opt-in `acceptanceTestSuites` configuration:

```yaml
acceptanceTestSuites:
  - name: yaml
    root: examples_yaml_test.go
    shards: 8
    requiresSDKs: false
  - name: sdk
    root: examples_test.go
    shards: 2
    requiresSDKs: true
```

Each suite gets its own reusable-workflow call and shard matrix. A
provider-only suite depends on `prerequisites` and `build_provider`; an
SDK-dependent suite additionally depends on `build_sdk`. Sentinel and publish
jobs wait for every configured suite and the SDK build.

The same fanout is generated for acceptance, main, nightly, prerelease, and
release workflows. Inside `test.yml`, generated SDK downloads, Make progress
restoration, Python SDK tooling, and `make install_sdks` only run when the suite
sets `requiresSDKs: true`. Provider download, ESC credentials, and shared test
setup remain available to both kinds of suite.

Existing providers retain the current `shards` or language-matrix behavior when
`acceptanceTestSuites` is absent. Native workflow templates reject the option
rather than silently ignoring it.

Some deliberate POC constraints:

- suite roots are relative to `test-folder`, non-overlapping, and shell-safe;
- each root must contain at least as many top-level tests as its shard count;
- file roots select top-level tests, but Go still compiles sibling package files
  and runs package initialization and `TestMain`;
- providers are responsible for arranging roots that cover every intended test;
- the AWS test-provider configuration is illustrative only. In particular,
  `examples_test.go` is not currently a deployable SDK-smoke root in pulumi-aws;
  real adoption must configure the test-bearing file or directory created for
  that migration.

The main review question is whether this suite/root/`requiresSDKs` model is the
right provider-facing API before investing in a production rollout.

Validation performed:

```text
cd provider-ci && make clean && make all
```

This includes Go tests, deterministic fixture regeneration, golangci-lint, and
actionlint across all generated test providers. Only the opted-in AWS fixture
changes; legacy fixtures remain unchanged.
