### PR TITLE
Fetch only the PR ref in the Renovate SDK commit step

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -118,9 +118,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -180,11 +180,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -346,11 +346,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -169,11 +169,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -333,11 +333,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -129,9 +129,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -126,9 +126,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -120,11 +120,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -266,11 +266,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -178,11 +178,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -330,11 +330,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -131,9 +131,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -128,9 +128,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -173,11 +173,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -322,11 +322,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -173,11 +173,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -322,11 +322,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -173,11 +173,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -322,11 +322,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -175,11 +175,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -322,11 +322,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -166,11 +166,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 
@@ -315,11 +315,11 @@ jobs:
 
         git config --global user.name "pulumi-bot"
 
-        # Stash local changes and check out the PR's branch directly.
+        # Stash local changes and check out the PR's branch directly, fetching only that ref so submodule recursion never sees gitlinks from unrelated branches.
 
         git stash
 
-        git fetch
+        git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
 
         git checkout "origin/$HEAD_REF"
 

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
@@ -124,9 +124,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -121,9 +121,13 @@ jobs:
           git config --global user.email "bot@pulumi.com"
           git config --global user.name "pulumi-bot"
 
-          # Stash local changes and check out the PR's branch directly.
+          # Stash local changes and check out the PR's branch directly. Fetch
+          # only that ref: a bare fetch pulls every branch in the repo, and
+          # on-demand submodule recursion then tries to resolve the submodule
+          # gitlink of every commit it pulls, including long-dead branches
+          # pointing at commits the submodule's remote no longer serves.
           git stash
-          git fetch
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
           git checkout "origin/$HEAD_REF"
 
           # Apply and add our changes, but don't commit any files we expect to


### PR DESCRIPTION
`build_sdk` (bridged) and `run-acceptance-tests` (native) have a step that commits regenerated SDKs back onto a Renovate PR. It ran a bare `git fetch` before checking out the PR branch.

A bare fetch uses the remote's default refspec, so it pulls every branch in the repo rather than the single ref the next line checks out. `fetch.recurseSubmodules` defaults to `on-demand`, so git then walks all of those newly fetched commits, collects the submodule gitlink each one points at, and asks the submodule's remote for any sha it doesn't already have locally. A branch untouched for years can carry a gitlink that remote no longer serves; that fetch fails, and since the step runs under `bash -e` it dies before the `git push` that would land the regenerated SDK.

Narrowing the refspec means only the PR's own commits are ever scanned. `--no-recurse-submodules` guards the same failure if the refspec is widened again later. It also drops the cost of fetching every branch and tag on each run.

Regenerated the checked-in test providers; actionlint and the Go tests pass.
