### PR TITLE
Split acceptance-test concurrency by actor and rebase-retry the SDK push

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -143,8 +143,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -14,9 +14,14 @@ env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
 #{{ .Config | renderGlobalEnv | indent 2 }}#
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -209,8 +209,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -374,8 +390,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -198,8 +198,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -361,8 +377,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -154,8 +154,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -20,9 +20,14 @@ env:
   PULUMI_PULUMI_ENABLE_JOURNALING: "true"
   TF_APPEND_USER_AGENT: pulumi
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -151,8 +151,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -18,9 +18,14 @@ env:
   PULUMI_PULUMI_ENABLE_JOURNALING: "true"
   TF_APPEND_USER_AGENT: pulumi
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -149,8 +149,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -294,8 +310,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -207,8 +207,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -358,8 +374,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -156,8 +156,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -30,9 +30,14 @@ env:
   PULUMI_PULUMI_ENABLE_JOURNALING: "true"
   TF_APPEND_USER_AGENT: pulumi
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -153,8 +153,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -27,9 +27,14 @@ env:
   PYTHON_VERSION: "3.9"
   TF_APPEND_USER_AGENT: pulumi
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -202,8 +202,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -350,8 +366,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -202,8 +202,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -350,8 +366,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -202,8 +202,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -350,8 +366,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -204,8 +204,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -350,8 +366,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -195,8 +195,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
@@ -343,8 +359,24 @@ jobs:
 
         # Push with pulumi-bot credentials to trigger a re-run of the
         # workflow. https://github.com/orgs/community/discussions/25702
+        #
+        # Another language's job may have pushed while this one was building,
+        # which makes our commit a non-fast-forward. Rebase onto the current
+        # tip and try again: the SDK commits touch disjoint paths
+        # (sdk/<language>/**), so the rebase applies cleanly.
 
-        git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+        for attempt in 1 2 3; do
+          if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} "HEAD:$HEAD_REF"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+          git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+          git rebase "refs/remotes/origin/$HEAD_REF"
+        done
+
+        echo "::error::Could not push the SDK commit after 3 attempts."
+
+        exit 1
       env:
         HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
@@ -149,8 +149,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/run-acceptance-tests.yml
@@ -23,9 +23,14 @@ env:
   PULUMI_TEST_USE_SERVICE: "true"
   TF_APPEND_USER_AGENT: pulumi
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
@@ -19,9 +19,14 @@ env:
   PULUMI_PULUMI_ENABLE_JOURNALING: "true"
   TF_APPEND_USER_AGENT: pulumi
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -146,8 +146,22 @@ jobs:
 
           # Push with pulumi-bot credentials to trigger a re-run of the
           # workflow. https://github.com/orgs/community/discussions/25702
-          git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
-              "HEAD:$HEAD_REF"
+          #
+          # Another language's job may have pushed while this one was building,
+          # which makes our commit a non-fast-forward. Rebase onto the current
+          # tip and try again: the SDK commits touch disjoint paths
+          # (sdk/<language>/**), so the rebase applies cleanly.
+          for attempt in 1 2 3; do
+            if git push https://pulumi-bot:${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+                "HEAD:$HEAD_REF"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current tip."
+            git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            git rebase "refs/remotes/origin/$HEAD_REF"
+          done
+          echo "::error::Could not push the SDK commit after 3 attempts."
+          exit 1
         env:
           # head_ref is untrusted so it's recommended to pass via env var to
           # avoid injections.

--- a/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/run-acceptance-tests.yml
@@ -20,9 +20,14 @@ env:
   TF_APPEND_USER_AGENT: pulumi
   XYZ_REGION: us-west-2
 
-# This should cancel any previous runs of the same workflow on the same branch which are still running.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Split the group by actor so a Renovate PR's run is not cancelled by the SDK
+  # commits its own build_sdk jobs push back to the branch. Those pushes are
+  # `synchronize` events by pulumi-bot, which now land in a separate group;
+  # without this the first language to push cancels the run the other four are
+  # still building in. A genuinely new Renovate force-push shares the group and
+  # still supersedes the stale run it replaces.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ contains(github.actor, 'renovate') && 'renovate' || 'other' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The build_sdk matrix commits regenerated SDKs back to a Renovate PR from each language job independently. Both halves of that raced: the first push was a `synchronize` event that cancelled the run its sibling jobs were still building in, and any job that did finish had its commit rejected as a non-fast-forward.

Splitting the concurrency group by actor keeps pulumi-bot's SDK pushes from cancelling the Renovate run while still letting a genuinely new Renovate force-push supersede the stale run it replaces. Retrying the push after rebasing onto the current tip resolves the remaining collisions; the SDK commits touch disjoint paths, so the rebase always applies.

Part of pulumi/home#4904

## Verification

Dispatched `update-workflows-single-bridged-provider` from this branch against one bridged and one native provider. Both generated PRs cite commit 6fe1573.

| Provider | Template | Generated PR | Checks |
|---|---|---|---|
| pulumi-command | native | pulumi/pulumi-command#1378 | 18 pass, 2 skipped |
| pulumi-gcp | bridged | pulumi/pulumi-gcp#3961 | 21 pass, 5 running |

Native touched only `run-acceptance-tests.yml`, bridged touched that plus `build_sdk.yml` and picked up the concurrency-group split.

The native retry sites sit inside `run: >` folded scalars, so the generated YAML was parsed back out to confirm the fold does not join shell statements: `for`, `if`, `fi`, `done`, `echo` and `exit 1` each land on their own line at both sites. The leading comment block does collapse into a single `#` line, which is cosmetic.

Coverage limit: the Renovate-only paths (`continue-on-error`, the commit step, the retry loop) are gated on `contains(github.actor, 'renovate')`, so a pulumi-bot-authored PR cannot exercise them. These runs prove the generated workflows are valid and that normal PRs are unaffected; the retry path is first exercised by a real Renovate PR after rollout.
