### PR TITLE
Add opt-in full Go caching for bridged providers

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -175,6 +175,10 @@ type Config struct {
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22goBuildParallelism%22&type=code
 	GoBuildParallelism int `yaml:"goBuildParallelism"`
 
+	// FullGoCache enables the shared Go module and build cache strategy in generated
+	// bridged-provider workflows. It does not configure repository cache storage.
+	FullGoCache bool `yaml:"fullGoCache"`
+
 	// PulumiConvert sets PULUMI_CONVERT to 1 if truthy. PulumiConvert is set
 	// to "1" in 74 providers:
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22pulumiConvert%22&type=code

--- a/provider-ci/internal/pkg/config_test.go
+++ b/provider-ci/internal/pkg/config_test.go
@@ -25,6 +25,25 @@ func TestLoadLocalConfigDefaultsMajorProviderUpgradesEnabled(t *testing.T) {
 	}
 }
 
+func TestLoadLocalConfigCanEnableFullGoCache(t *testing.T) {
+	dir := t.TempDir()
+
+	configPath := filepath.Join(dir, ".ci-mgmt.yaml")
+	if err := os.WriteFile(configPath, []byte(`provider: aws
+fullGoCache: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadLocalConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !config.FullGoCache {
+		t.Fatal("expected local config to enable the Go cache")
+	}
+}
+
 func TestLoadLocalConfigCanDisableMajorProviderUpgrades(t *testing.T) {
 	dir := t.TempDir()
 

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -95,6 +96,13 @@ func GeneratePackage(opts GenerateOpts) error {
 		}
 	}
 	for _, deletedFile := range getConfigDeletedFiles(opts.Config) {
+		err = os.RemoveAll(filepath.Join(opts.OutDir, deletedFile))
+		if err != nil {
+			return fmt.Errorf("error deleting file %s: %w", deletedFile, err)
+		}
+	}
+	if !opts.Config.FullGoCache && slices.Contains(templateDirs, base) {
+		deletedFile := filepath.Join(".github", "actions", "setup-go-cache", "action.yml")
 		err = os.RemoveAll(filepath.Join(opts.OutDir, deletedFile))
 		if err != nil {
 			return fmt.Errorf("error deleting file %s: %w", deletedFile, err)
@@ -207,9 +215,6 @@ func getConfigDeletedFiles(config Config) []string {
 		".github/workflows/gh-aw-pr-review.md",
 		filepath.Join(".github", "workflows", "shared", "review.md"),
 		filepath.Join(".github", "workflows", "shared", "plugins", "code-review", "code-review.md"),
-	}
-	if !config.FullGoCache {
-		deletedFiles = append(deletedFiles, filepath.Join(".github", "actions", "setup-go-cache", "action.yml"))
 	}
 	return deletedFiles
 }

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -208,6 +208,9 @@ func getConfigDeletedFiles(config Config) []string {
 		filepath.Join(".github", "workflows", "shared", "review.md"),
 		filepath.Join(".github", "workflows", "shared", "plugins", "code-review", "code-review.md"),
 	}
+	if !config.FullGoCache {
+		deletedFiles = append(deletedFiles, filepath.Join(".github", "actions", "setup-go-cache", "action.yml"))
+	}
 	return deletedFiles
 }
 

--- a/provider-ci/internal/pkg/templates/base/.github/actions/setup-go-cache/action.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/actions/setup-go-cache/action.yml
@@ -1,0 +1,104 @@
+#{{- if .Config.FullGoCache -}}#
+name: Setup Go cache
+description: Restore Go module and build caches for generated provider workflows
+
+inputs:
+  cache-key:
+    description: Identifies the workload that writes the build cache
+    required: true
+  target-os:
+    description: GOOS compiled by this workload; defaults to the host GOOS
+    required: false
+    default: ""
+  target-arch:
+    description: GOARCH compiled by this workload; defaults to the host GOARCH
+    required: false
+    default: ""
+  prime-modules:
+    description: Download dependencies for the checked-out Go modules before saving the module cache
+    required: false
+    default: "false"
+  save:
+    description: Save caches when the job succeeds
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Get Go cache configuration
+      id: cache-config
+      shell: bash
+      env:
+        TARGET_OS: ${{ inputs.target-os }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: |
+        set -euo pipefail
+        echo "build-cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "module-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+        echo "target-os=${TARGET_OS:-$(go env GOOS)}" >> "$GITHUB_OUTPUT"
+        echo "target-arch=${TARGET_ARCH:-$(go env GOARCH)}" >> "$GITHUB_OUTPUT"
+
+    - name: Prepare Go module cache restore
+      shell: bash
+      env:
+        MODULE_CACHE: ${{ steps.cache-config.outputs.module-cache }}
+      run: |
+        set -euo pipefail
+        if [[ -z "$MODULE_CACHE" || "$MODULE_CACHE" == "/" ]]; then
+          echo "Refusing to remove unsafe Go module cache path: '$MODULE_CACHE'" >&2
+          exit 1
+        fi
+        rm -rf -- "$MODULE_CACHE"
+
+    - name: Restore and save Go module cache
+      if: inputs.save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.module-cache }}
+        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Restore Go module cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.module-cache }}
+        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Prime Go module cache
+      if: inputs.prime-modules == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        while IFS= read -r -d '' dependency_file; do
+          module_dir=$(dirname "$dependency_file")
+          if [[ -f "$module_dir/go.mod" ]]; then
+            (cd "$module_dir" && go mod download)
+          fi
+        done < <(find . -type f -name go.sum -not -path './.git/*' -print0 | sort -z)
+
+    - name: Restore and save Go build cache
+      if: inputs.save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.build-cache }}
+        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-
+
+    - name: Restore Go build cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.build-cache }}
+        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-
+#{{- end }}#

--- a/provider-ci/internal/pkg/templates/base/.github/actions/setup-go-cache/action.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/actions/setup-go-cache/action.yml
@@ -18,10 +18,6 @@ inputs:
     description: Download dependencies for the checked-out Go modules before saving the module cache
     required: false
     default: "false"
-  save:
-    description: Save caches when the job succeeds
-    required: false
-    default: "true"
 
 runs:
   using: composite
@@ -53,17 +49,7 @@ runs:
         rm -rf -- "$MODULE_CACHE"
 
     - name: Restore and save Go module cache
-      if: inputs.save == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ${{ steps.cache-config.outputs.module-cache }}
-        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
-
-    - name: Restore Go module cache
-      if: inputs.save != 'true'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ${{ steps.cache-config.outputs.module-cache }}
         key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
@@ -83,18 +69,7 @@ runs:
         done < <(find . -type f -name go.sum -not -path './.git/*' -print0 | sort -z)
 
     - name: Restore and save Go build cache
-      if: inputs.save == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ${{ steps.cache-config.outputs.build-cache }}
-        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
-        restore-keys: |
-          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
-          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-
-
-    - name: Restore Go build cache
-      if: inputs.save != 'true'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ${{ steps.cache-config.outputs.build-cache }}
         key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -78,6 +78,14 @@ jobs:
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
           # only saving the cache in the prerequisites job
           cache_save: false
+#{{- if .Config.FullGoCache }}#
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
+        with:
+          cache-key: provider
+          target-os: ${{ matrix.platform.os }}
+          target-arch: ${{ matrix.platform.arch }}
+#{{- else }}#
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE
         id: gocache
@@ -98,6 +106,7 @@ jobs:
           key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('#{{ .Config.ModulePath }}#/go.sum') }}
           restore-keys: |
             go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
+#{{- end }}#
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
         env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -69,6 +69,13 @@ jobs:
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
           # only saving the cache in the prerequisites job
           cache_save: false
+#{{- if .Config.FullGoCache }}#
+      - name: Setup Go cache
+        if: matrix.language == 'go' || contains(matrix.language, 'go')
+        uses: ./.github/actions/setup-go-cache
+        with:
+          cache-key: sdk-go
+#{{- else }}#
       - name: Setup Go Cache
         if: matrix.language == 'go' || contains(matrix.language, 'go')
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -79,6 +86,7 @@ jobs:
             sdk/go/*.sum
             sdk/*.sum
             *.sum
+#{{- end }}#
       - name: Prepare local workspace
         run: make prepare_local_workspace
         env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -84,6 +84,13 @@ jobs:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         # only saving the cache in the prerequisites job
         cache_save: true
+#{{- if .Config.FullGoCache }}#
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
+      with:
+        cache-key: prerequisites
+        prime-modules: true
+#{{- else }}#
     #{{- if and (not .Config.NoSchema) (not .Config.UseProviderBinarySchemaGen) }}#
     - name: Setup Go Cache
       if: inputs.acceptance_fanout
@@ -114,6 +121,7 @@ jobs:
           sdk/*.sum
           *.sum
     #{{- end }}#
+#{{- end }}#
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -184,12 +184,7 @@ jobs:
         version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         cache_save: false
-#{{- if .Config.FullGoCache }}#
-    - name: Setup Go cache
-      uses: ./.github/actions/setup-go-cache
-      with:
-        cache-key: schema
-#{{- else }}#
+#{{- if not .Config.FullGoCache }}#
     - name: Restore Go Cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -98,6 +98,12 @@ jobs:
         version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         cache_save: false
+#{{- if .Config.FullGoCache }}#
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
+      with:
+        cache-key: test-provider
+#{{- else }}#
     - name: Restore Go Cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
@@ -105,6 +111,7 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+#{{- end }}#
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:
@@ -177,6 +184,12 @@ jobs:
         version: #{{ .Config.MiseVersion }}#
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         cache_save: false
+#{{- if .Config.FullGoCache }}#
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
+      with:
+        cache-key: schema
+#{{- else }}#
     - name: Restore Go Cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
@@ -184,6 +197,7 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+#{{- end }}#
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Download bin
       uses: ./.github/actions/download-provider
-#{{- if and (not .Config.FullGoCache) (not .Config.Shards) }}#
+#{{- if not .Config.Shards }}#
     - name: Setup Go Cache
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       if: matrix.language == 'go' || contains(matrix.language, 'go')

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 #{{- end }}#
+#{{- if not .Config.FullGoCache }}#
     - name: Checkout p/examples
       #{{- if not .Config.Shards }}#
       if: matrix.testTarget == 'pulumiExamples'
@@ -60,6 +61,7 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
+#{{- end }}#
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -70,13 +72,35 @@ jobs:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         # also save this cache since we are using a different mise env.
         cache_save: true
+#{{- if .Config.FullGoCache }}#
+    - name: Setup Go cache
+      #{{- if not .Config.Shards }}#
+      if: matrix.language == 'go' || contains(matrix.language, 'go')
+      #{{- end }}#
+      uses: ./.github/actions/setup-go-cache
+      with:
+        cache-key: integration-tests
+        #{{- if .Config.Shards }}#
+        save: ${{ matrix.current-shard == 0 }}
+        #{{- end }}#
+#{{- end }}#
+#{{- if .Config.FullGoCache }}#
+    - name: Checkout p/examples
+      #{{- if not .Config.Shards }}#
+      if: matrix.testTarget == 'pulumiExamples'
+      #{{- end }}#
+      uses: #{{ .Config.ActionVersions.Checkout }}#
+      with:
+        repository: pulumi/examples
+        path: p-examples
+#{{- end }}#
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Download bin
       uses: ./.github/actions/download-provider
-    #{{- if not .Config.Shards }}#
+#{{- if and (not .Config.FullGoCache) (not .Config.Shards) }}#
     - name: Setup Go Cache
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       if: matrix.language == 'go' || contains(matrix.language, 'go')
@@ -87,6 +111,8 @@ jobs:
           sdk/go/*.sum
           sdk/*.sum
           *.sum
+#{{- end }}#
+    #{{- if not .Config.Shards }}#
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 #{{- end }}#
-#{{- if not .Config.FullGoCache }}#
     - name: Checkout p/examples
       #{{- if not .Config.Shards }}#
       if: matrix.testTarget == 'pulumiExamples'
@@ -61,7 +60,6 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
-#{{- end }}#
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -72,28 +70,6 @@ jobs:
         github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
         # also save this cache since we are using a different mise env.
         cache_save: true
-#{{- if .Config.FullGoCache }}#
-    - name: Setup Go cache
-      #{{- if not .Config.Shards }}#
-      if: matrix.language == 'go' || contains(matrix.language, 'go')
-      #{{- end }}#
-      uses: ./.github/actions/setup-go-cache
-      with:
-        cache-key: integration-tests
-        #{{- if .Config.Shards }}#
-        save: ${{ matrix.current-shard == 0 }}
-        #{{- end }}#
-#{{- end }}#
-#{{- if .Config.FullGoCache }}#
-    - name: Checkout p/examples
-      #{{- if not .Config.Shards }}#
-      if: matrix.testTarget == 'pulumiExamples'
-      #{{- end }}#
-      uses: #{{ .Config.ActionVersions.Checkout }}#
-      with:
-        repository: pulumi/examples
-        path: p-examples
-#{{- end }}#
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/verify-release.yml
@@ -80,6 +80,12 @@ jobs:
           version: #{{ .Config.MiseVersion }}#
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
+#{{- if .Config.FullGoCache }}#
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
+        with:
+          cache-key: verify-release
+#{{- else }}#
       - name: Setup Go Cache
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -89,6 +95,7 @@ jobs:
             sdk/go/*.sum
             sdk/*.sum
             *.sum
+#{{- end }}#
 #{{- if .Config.ReleaseVerification }}#
       #{{- if .Config.AWS }}#
       - name: Generate Pulumi Access Token

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -167,6 +167,10 @@ checkUpstreamUpgrade: true
 # Used in 5 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22goBuildParallelism%22&type=code
 #goBuildParallelism: 1
 
+# Enables shared Go module and build caches in generated bridged-provider workflows.
+# Repository cache storage is configured separately.
+fullGoCache: false
+
 # Sets PULUMI_CONVERT to 1 if truthy
 # Is set to "1" in 74 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22pulumiConvert%22&type=code
 #pulumiConvert: false

--- a/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
+++ b/provider-ci/internal/pkg/templates/internal-bridged/.github/workflows/main-post-build.yml
@@ -57,6 +57,12 @@ jobs:
           github_token: #{{ if .Config.GitHubApp.Enabled }}#${{ steps.app-auth.outputs.token }}#{{ else }}#${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}#{{ end }}#
           # only saving the cache in the prerequisites job
           cache_save: false
+#{{- if .Config.FullGoCache }}#
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
+        with:
+          cache-key: coverage
+#{{- else }}#
       - name: Setup Go Cache
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -66,6 +72,7 @@ jobs:
             sdk/go/*.sum
             sdk/*.sum
             *.sum
+#{{- end }}#
       - name: Echo Coverage Output Dir
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -28,6 +28,7 @@ XrunUpstreamTools: true
 pulumiConvert: 1
 allowMissingDocs: false
 goBuildParallelism: 2
+fullGoCache: true
 aws: true
 releaseVerification:
     nodejs: examples/release-verification

--- a/provider-ci/test-providers/aws/.github/actions/setup-go-cache/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-go-cache/action.yml
@@ -1,0 +1,102 @@
+name: Setup Go cache
+description: Restore Go module and build caches for generated provider workflows
+
+inputs:
+  cache-key:
+    description: Identifies the workload that writes the build cache
+    required: true
+  target-os:
+    description: GOOS compiled by this workload; defaults to the host GOOS
+    required: false
+    default: ""
+  target-arch:
+    description: GOARCH compiled by this workload; defaults to the host GOARCH
+    required: false
+    default: ""
+  prime-modules:
+    description: Download dependencies for the checked-out Go modules before saving the module cache
+    required: false
+    default: "false"
+  save:
+    description: Save caches when the job succeeds
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Get Go cache configuration
+      id: cache-config
+      shell: bash
+      env:
+        TARGET_OS: ${{ inputs.target-os }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: |
+        set -euo pipefail
+        echo "build-cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "module-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+        echo "target-os=${TARGET_OS:-$(go env GOOS)}" >> "$GITHUB_OUTPUT"
+        echo "target-arch=${TARGET_ARCH:-$(go env GOARCH)}" >> "$GITHUB_OUTPUT"
+
+    - name: Prepare Go module cache restore
+      shell: bash
+      env:
+        MODULE_CACHE: ${{ steps.cache-config.outputs.module-cache }}
+      run: |
+        set -euo pipefail
+        if [[ -z "$MODULE_CACHE" || "$MODULE_CACHE" == "/" ]]; then
+          echo "Refusing to remove unsafe Go module cache path: '$MODULE_CACHE'" >&2
+          exit 1
+        fi
+        rm -rf -- "$MODULE_CACHE"
+
+    - name: Restore and save Go module cache
+      if: inputs.save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.module-cache }}
+        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Restore Go module cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.module-cache }}
+        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Prime Go module cache
+      if: inputs.prime-modules == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        while IFS= read -r -d '' dependency_file; do
+          module_dir=$(dirname "$dependency_file")
+          if [[ -f "$module_dir/go.mod" ]]; then
+            (cd "$module_dir" && go mod download)
+          fi
+        done < <(find . -type f -name go.sum -not -path './.git/*' -print0 | sort -z)
+
+    - name: Restore and save Go build cache
+      if: inputs.save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.build-cache }}
+        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-
+
+    - name: Restore Go build cache
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ${{ steps.cache-config.outputs.build-cache }}
+        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
+        restore-keys: |
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
+          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-

--- a/provider-ci/test-providers/aws/.github/actions/setup-go-cache/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-go-cache/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: Download dependencies for the checked-out Go modules before saving the module cache
     required: false
     default: "false"
-  save:
-    description: Save caches when the job succeeds
-    required: false
-    default: "true"
 
 runs:
   using: composite
@@ -52,17 +48,7 @@ runs:
         rm -rf -- "$MODULE_CACHE"
 
     - name: Restore and save Go module cache
-      if: inputs.save == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ${{ steps.cache-config.outputs.module-cache }}
-        key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          go-mod-v2-${{ runner.os }}-${{ runner.arch }}-
-
-    - name: Restore Go module cache
-      if: inputs.save != 'true'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ${{ steps.cache-config.outputs.module-cache }}
         key: go-mod-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
@@ -82,18 +68,7 @@ runs:
         done < <(find . -type f -name go.sum -not -path './.git/*' -print0 | sort -z)
 
     - name: Restore and save Go build cache
-      if: inputs.save == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ${{ steps.cache-config.outputs.build-cache }}
-        key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}
-        restore-keys: |
-          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-
-          go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-
-
-    - name: Restore Go build cache
-      if: inputs.save != 'true'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ${{ steps.cache-config.outputs.build-cache }}
         key: go-build-v2-${{ steps.cache-config.outputs.target-os }}-${{ steps.cache-config.outputs.target-arch }}-${{ steps.cache-config.outputs.go-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/*.go', '**/go.sum') }}

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -80,26 +80,12 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
           # only saving the cache in the prerequisites job
           cache_save: false
-      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
-      - name: Get GOCACHE
-        id: gocache
-        shell: bash
-        run: |
-          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
-      - name: Get GOMODCACHE
-        id: gomodcache
-        shell: bash
-        run: |
-          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
-      - name: Go Cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
         with:
-          path: |
-            ${{ steps.gocache.outputs.path }}
-            ${{ steps.gomodcache.outputs.path }}
-          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
-          restore-keys: |
-            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
+          cache-key: provider
+          target-os: ${{ matrix.platform.os }}
+          target-arch: ${{ matrix.platform.arch }}
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
         env:

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -80,16 +80,11 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
           # only saving the cache in the prerequisites job
           cache_save: false
-      - name: Setup Go Cache
+      - name: Setup Go cache
         if: matrix.language == 'go' || contains(matrix.language, 'go')
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        uses: ./.github/actions/setup-go-cache
         with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-            sdk/go/*.sum
-            sdk/*.sum
-            *.sum
+          cache-key: sdk-go
       - name: Prepare local workspace
         run: make prepare_local_workspace
         env:

--- a/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/main-post-build.yml
@@ -67,15 +67,10 @@ jobs:
           github_token: ${{ steps.app-auth.outputs.token }}
           # only saving the cache in the prerequisites job
           cache_save: false
-      - name: Setup Go Cache
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
         with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-            sdk/go/*.sum
-            sdk/*.sum
-            *.sum
+          cache-key: coverage
       - name: Echo Coverage Output Dir
         run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
       - name: Generate Coverage Data

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -90,24 +90,11 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # only saving the cache in the prerequisites job
         cache_save: true
-    - name: Setup Go Cache
-      if: inputs.acceptance_fanout
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
-    - name: Setup Go Cache
-      if: inputs.acceptance_fanout == false
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-      with:
-        cache-dependency-path: |
-          provider/*.sum
-          upstream/*.sum
-          sdk/go/*.sum
-          sdk/*.sum
-          *.sum
+        cache-key: prerequisites
+        prime-modules: true
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -173,10 +173,6 @@ jobs:
         version: 2026.3.7
         github_token: ${{ steps.app-auth.outputs.token }}
         cache_save: false
-    - name: Setup Go cache
-      uses: ./.github/actions/setup-go-cache
-      with:
-        cache-key: schema
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -102,13 +102,10 @@ jobs:
         version: 2026.3.7
         github_token: ${{ steps.app-auth.outputs.token }}
         cache_save: false
-    - name: Restore Go Cache
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+        cache-key: test-provider
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:
@@ -176,13 +173,10 @@ jobs:
         version: 2026.3.7
         github_token: ${{ steps.app-auth.outputs.token }}
         cache_save: false
-    - name: Restore Go Cache
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-prerequisites-${{ hashFiles('provider/*.sum', 'upstream/*.sum', 'sdk/go/*.sum', 'sdk/*.sum', '*.sum') }}
+        cache-key: schema
     - name: Prepare local workspace before restoring previously built files
       run: make prepare_local_workspace
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -60,6 +60,11 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
+    - name: Checkout p/examples
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: pulumi/examples
+        path: p-examples
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -70,16 +75,6 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # also save this cache since we are using a different mise env.
         cache_save: true
-    - name: Setup Go cache
-      uses: ./.github/actions/setup-go-cache
-      with:
-        cache-key: integration-tests
-        save: ${{ matrix.current-shard == 0 }}
-    - name: Checkout p/examples
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        repository: pulumi/examples
-        path: p-examples
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -60,11 +60,6 @@ jobs:
         app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
-    - name: Checkout p/examples
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        repository: pulumi/examples
-        path: p-examples
     - name: Setup mise
       uses: jdx/mise-action@8d3b0ba20a9cea7b883d922ea958553c941ab082
       env:
@@ -75,6 +70,16 @@ jobs:
         github_token: ${{ steps.app-auth.outputs.token }}
         # also save this cache since we are using a different mise env.
         cache_save: true
+    - name: Setup Go cache
+      uses: ./.github/actions/setup-go-cache
+      with:
+        cache-key: integration-tests
+        save: ${{ matrix.current-shard == 0 }}
+    - name: Checkout p/examples
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: pulumi/examples
+        path: p-examples
     - name: Prepare local workspace
       run: make prepare_local_workspace
       env:

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -76,15 +76,10 @@ jobs:
           version: 2026.3.7
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cache_save: false
-      - name: Setup Go Cache
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Setup Go cache
+        uses: ./.github/actions/setup-go-cache
         with:
-          cache-dependency-path: |
-            provider/*.sum
-            upstream/*.sum
-            sdk/go/*.sum
-            sdk/*.sum
-            *.sum
+          cache-key: verify-release
       - name: Generate Pulumi Access Token
         id: generate_pulumi_token
         uses: pulumi/auth-actions@141415910c3beb54e03b48e9057c204c97b956f2 # v2.1.0


### PR DESCRIPTION
This PR adds an opt-in cache strategy for providers with high Go compilation costs:

```yaml
fullGoCache: true
```

When enabled, the affected jobs:

1. Restore one shared module cache. Prerequisites downloads dependencies for every checked-in Go module so that the first saved entry is complete.
2. Restore a build cache for the job’s workload, target, Go version, and source revision.
3. Fall back to build output from an earlier revision when there is no exact match.
4. Save the updated build cache after compiling the current source.

This lets unit tests, provider builds, SDK builds, and other compilation-heavy jobs reuse compiled package files while still saving the work produced by each job. Schema generation and integration tests are excluded because cache transfer took as much time as it saved.

The option is disabled by default. It creates more cache entries than the existing strategy, so it is intended for providers where the time savings justify the storage. The AWS experiment used a 200 GB limit, with a maximum cost of approximately $13 per month.

## Validation

- `cd provider-ci && make clean && make all`
- [pulumi-aws#6624](https://github.com/pulumi/pulumi-aws/pull/6624) passed all required checks, including `Sentinel`.

| AWS workflow | Total time |
|---|---:|
| [Before](https://github.com/pulumi/pulumi-aws/actions/runs/32752943571) | 63m58s |
| [Exact-source warm cache](https://github.com/pulumi/pulumi-aws/actions/runs/32841762106) | 46m32s |

The exact-source warm run was 17m26s, or 27%, faster. This is the best-case cache behavior: it reused build output saved for the same Go source.

Normal PRs will usually change Go source and miss the exact key. After this rolls out to `pulumi-aws`, a successful `master` build will seed the caches. New PRs can then restore the latest compatible `master` cache through the fallback key and rebuild only affected packages. That production path has not yet been measured.

The AWS experiment also cached schema and integration-test jobs. Measurements showed no end-to-end benefit for those jobs, so the final version excludes them. Push and tag-only release paths were not exercised.
