### PR TITLE
Build Go SDK packages in one invocation

### DIFF
--- a/provider-ci/internal/pkg/templates/base/Makefile
+++ b/provider-ci/internal/pkg/templates/base/Makefile
@@ -186,7 +186,7 @@ build_go: .make/build_go
 	@touch $@
 #{{- end }}#
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -147,7 +147,7 @@ build_go: .make/build_go
 	$(POST_GEN_SDK_GO)
 	@touch $@
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -147,7 +147,7 @@ build_go: .make/build_go
 	$(POST_GEN_SDK_GO)
 	@touch $@
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -147,7 +147,7 @@ build_go: .make/build_go
 	$(POST_GEN_SDK_GO)
 	@touch $@
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -147,7 +147,7 @@ build_go: .make/build_go
 	$(POST_GEN_SDK_GO)
 	@touch $@
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 

--- a/provider-ci/test-providers/pulumiservice/Makefile
+++ b/provider-ci/test-providers/pulumiservice/Makefile
@@ -147,7 +147,7 @@ build_go: .make/build_go
 	$(POST_GEN_SDK_GO)
 	@touch $@
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 

--- a/provider-ci/test-providers/xyz/Makefile
+++ b/provider-ci/test-providers/xyz/Makefile
@@ -147,7 +147,7 @@ build_go: .make/build_go
 	$(POST_GEN_SDK_GO)
 	@touch $@
 .make/build_go: .make/generate_go
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	cd sdk && go build ./go/...
 	@touch $@
 .PHONY: generate_go build_go
 


### PR DESCRIPTION
Build generated Go SDK packages with one `go build` invocation instead of starting `go build` and `go clean` separately for every package. This avoids repeated command overhead and lets Go schedule the complete package graph.

In [pulumi-aws#6625](https://github.com/pulumi/pulumi-aws/pull/6625), this reduced the warm Go SDK build step from 10 minutes to 39 seconds.

Validation: `cd provider-ci && make clean && make all`
