### PR TITLE
Autostash before rebasing the SDK commit

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_sdk.yml
@@ -163,7 +163,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1

--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -221,7 +221,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -402,7 +407,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws-native/.github/workflows/run-acceptance-tests.yml
@@ -210,7 +210,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -389,7 +394,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -161,7 +161,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -163,7 +163,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1

--- a/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/command/.github/workflows/run-acceptance-tests.yml
@@ -161,7 +161,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -322,7 +327,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker-build/.github/workflows/run-acceptance-tests.yml
@@ -219,7 +219,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -386,7 +391,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -168,7 +168,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -165,7 +165,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1

--- a/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-cert-manager/.github/workflows/run-acceptance-tests.yml
@@ -214,7 +214,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -378,7 +383,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-coredns/.github/workflows/run-acceptance-tests.yml
@@ -214,7 +214,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -378,7 +383,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes-ingress-nginx/.github/workflows/run-acceptance-tests.yml
@@ -214,7 +214,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -378,7 +383,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -216,7 +216,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -378,7 +383,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/pulumi-provider-boilerplate/.github/workflows/run-acceptance-tests.yml
@@ -207,7 +207,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."
@@ -371,7 +376,12 @@ jobs:
           fi
           echo "Push rejected (attempt $attempt); rebasing onto the current tip."
           git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-          git rebase "refs/remotes/origin/$HEAD_REF"
+          # --autostash because the `git reset` above deliberately leaves the
+          # always-changing files modified, and rebase refuses a dirty tree.
+          if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+            echo "::error::Rebase onto $HEAD_REF failed; the SDK commit must be applied by hand."
+            exit 1
+          fi
         done
 
         echo "::error::Could not push the SDK commit after 3 attempts."

--- a/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/pulumiservice/.github/workflows/build_sdk.yml
@@ -161,7 +161,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1

--- a/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/xyz/.github/workflows/build_sdk.yml
@@ -158,7 +158,12 @@ jobs:
             fi
             echo "Push rejected (attempt $attempt); rebasing onto the current tip."
             git fetch --no-recurse-submodules origin "+refs/heads/$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            git rebase "refs/remotes/origin/$HEAD_REF"
+            # --autostash because the `git reset` above deliberately leaves the
+            # always-changing files modified, and rebase refuses a dirty tree.
+            if ! git rebase --autostash "refs/remotes/origin/$HEAD_REF"; then
+              echo "::error::Rebase onto $HEAD_REF failed; the ${{ matrix.language }} SDK commit must be applied by hand."
+              exit 1
+            fi
           done
           echo "::error::Could not push the SDK commit after 3 attempts."
           exit 1


### PR DESCRIPTION
The commit step deliberately leaves the always-changing versioned files unstaged via `git reset`, so the rebase added to the push-retry loop failed with `cannot rebase: You have unstaged changes`. Under `set -e` that killed the step outright, with no annotation and without trying the remaining attempts.

Observed on https://github.com/pulumi/pulumi-awsx/actions/runs/32955028372/job/98134917274 — the push was correctly rejected as a non-fast-forward, the retry caught it, and the rebase then failed on the dirty tree.

`--autostash` handles the dirty tree. Wrapping the rebase keeps `set -e` from aborting mid-loop and turns a genuine rebase failure into a named error saying which SDK needs to be pushed by hand.

Part of pulumi/home#4904
