### PR TITLE
Bump KinD cluster version

### DIFF
--- a/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/native/.github/workflows/run-acceptance-tests.yml
@@ -554,7 +554,7 @@ jobs:
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
-        node_image: kindest/node:v1.29.2
+        node_image: kindest/node:v1.36.4
         config: scripts/kind-config.yaml
     - name: Install KinD prerequisites (Calico + MetalLB + Traefik)
       run: ./scripts/setup-kind-cluster.sh

--- a/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/kubernetes/.github/workflows/run-acceptance-tests.yml
@@ -529,7 +529,7 @@ jobs:
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
-        node_image: kindest/node:v1.29.2
+        node_image: kindest/node:v1.36.4
         config: scripts/kind-config.yaml
     - name: Install KinD prerequisites (Calico + MetalLB + Traefik)
       run: ./scripts/setup-kind-cluster.sh


### PR DESCRIPTION
This bumps the Kubernetes test cluster to using  Kubernetes node version v1.36.4 

Note we're not using v1.37 yet because surrounding tooling in the ecosystem is still coming out with newest-compatible versions.