### PR TITLE
Add a disableIntegrationTests toggle

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -126,6 +126,13 @@ type Config struct {
 	// the examples directory when set to true. Defaults to false.
 	IntegrationTestProvider bool `yaml:"integrationTestProvider"`
 
+	// DisableIntegrationTests replaces the body of the "test" job with a no-op
+	// when set to true. The job is kept rather than removed so that the
+	// workflows declaring `needs: test` stay green. Intended for LTS branches
+	// whose acceptance tests can no longer run. Unit tests are unaffected:
+	// they run from prerequisites.yml.
+	DisableIntegrationTests bool `yaml:"disableIntegrationTests"`
+
 	// TestPulumiExamples runs e2e tests using the examples and test suite in
 	// the pulumi/examples repo when set to true. Defaults to false. This is
 	// unused but potentially useful for azure-native onboarding:

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/test.yml
@@ -19,6 +19,12 @@ env:
 
 jobs:
   test:
+#{{- if .Config.DisableIntegrationTests }}#
+    runs-on: ubuntu-latest
+    steps:
+    - name: Integration tests disabled
+      run: echo "Integration tests are disabled for this branch."
+#{{- else }}#
     permissions:
       contents: read
       id-token: write
@@ -222,4 +228,5 @@ jobs:
         #{{- else }}#
         testTarget: [local]
         #{{- end }}#
+#{{- end }}#
 #{{- end }}#


### PR DESCRIPTION
Adds a `disableIntegrationTests` option to `.ci-mgmt.yaml` for LTS branches whose acceptance tests can no longer run.

When set, the `test` job renders as a no-op instead of being removed, so `release.yml`, `prerelease.yml`, `nightly-test.yml`, `run-acceptance-tests.yml` and `main.yml` all keep resolving `needs: test`. Unit tests are unaffected; they run from `prerequisites.yml`.

Defaults to false. Generating a provider with the flag off produces a byte-identical `test.yml` to the committed golden, the stub passes actionlint, and `go test ./internal/...` is green.
