### PR TITLE
Track the azuread v5 branch

### DIFF
--- a/provider-ci/tracked-branches.json
+++ b/provider-ci/tracked-branches.json
@@ -1,3 +1,4 @@
 {
-    "gcp": ["upgrade-to-v10-major"]
+    "gcp": ["upgrade-to-v10-major"],
+    "azuread": ["v5"]
 }


### PR DESCRIPTION
Adds the `v5` branch of pulumi-azuread to `tracked-branches.json` so it stays on current tooling.

Do not merge yet. That branch carries four deliberate divergences from the generated output, and `deploy-tracked-branches` auto-merges on the nightly schedule, so tracking it today would silently revert them. Only one is expressible in config so far, via the `disableIntegrationTests` toggle. The others are the npm `latest-v5` dist-tag in the publish workflow, the `vfox-pulumi` plugin pins that `pulumi convert` needs at tfgen time, and a Java SDK recipe that uses `pulumi-java-gen` because the pinned bridge cannot emit Java.

See pulumi/pulumi-azuread#2511 for the catch-up PR those were found in.
