### PR TITLE
Pin --abbrev=12 when exporting patches so index-line hash width stops varying between machines

### DIFF
--- a/provider-ci/internal/pkg/templates/base/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/base/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/aws/scripts/upstream.sh
+++ b/provider-ci/test-providers/aws/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/docker/scripts/upstream.sh
+++ b/provider-ci/test-providers/docker/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/eks/scripts/upstream.sh
+++ b/provider-ci/test-providers/eks/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/pulumiservice/scripts/upstream.sh
+++ b/provider-ci/test-providers/pulumiservice/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/terraform-module/scripts/upstream.sh
+++ b/provider-ci/test-providers/terraform-module/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {

--- a/provider-ci/test-providers/xyz/scripts/upstream.sh
+++ b/provider-ci/test-providers/xyz/scripts/upstream.sh
@@ -302,7 +302,9 @@ export_patches() {
   
   # Extract patches from the commits in the 'pulumi/patch-checkout' branch into the 'patches' directory.
   # Use the 'pulumi/checkout-base' branch to determine the base commit of the patches.
-  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered)
+  # Pin --abbrev so patches don't differ between machines: git's default width
+  # varies with the upstream clone's object count.
+  (cd upstream && git format-patch pulumi/checkout-base -o ../patches --zero-commit --no-signature --no-stat --no-numbered --abbrev=12)
 }
 
 format_patches() {


### PR DESCRIPTION
`git format-patch` isn't pinned to a fixed `--abbrev`, so the blob hashes in each patch's `index` line get a width that scales with the local `upstream` clone's object count. Provider submodules sit near a width boundary, so regenerating from a differently-sized clone rewrites every patch file with no semantic change and buries real changes in diff noise. The width doesn't affect whether a patch applies; index hashes resolve by prefix.

Pinning `--abbrev=12` puts it above the range git's default reaches in practice. This causes a one-time rewrite of existing patch files in each provider repo on their next regeneration; content is unchanged and subsequent regenerations are stable.

Fixtures regenerated with `make -C provider-ci gen`.
